### PR TITLE
feat: Implement provider's agenda view for appointments

### DIFF
--- a/backend/app/models/scheduling.py
+++ b/backend/app/models/scheduling.py
@@ -152,5 +152,8 @@ class Appointment(BaseModel):
             # Incluimos el objeto de servicio completo, que ya contiene el establecimiento.
             'service': self.service.to_dict() if self.service else None,
             
+            # --- AÑADIMOS LA INFORMACIÓN DEL CLIENTE ---
+            'user': self.user.to_dict() if self.user else None,
+
             **self.to_dict_base()
         }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,6 +23,7 @@ import ConfirmBookingPage from './pages/ConfirmBookingPage';
 import BookingSuccessPage from './pages/BookingSuccessPage';
 import ClientAppointments from './pages/ClientAppointments';
 import ProtectedRoute from './components/auth/ProtectedRoute';
+import ProviderAppointments from './pages/ProviderAppointments';
 
 function App() {
   const [token, setToken] = useState(localStorage.getItem('accessToken'));
@@ -88,6 +89,7 @@ function App() {
                 <Route path="provider/establishments/new" element={<CreateEstablishment />} />
                 <Route path="provider/services" element={<ManageServices />} />
                 <Route path="provider/availability" element={<ManageAvailability />} />
+                <Route path="provider/appointments" element={<ProviderAppointments />} />
               </>
             )}
 

--- a/frontend/src/pages/ManageEstablishments.jsx
+++ b/frontend/src/pages/ManageEstablishments.jsx
@@ -3,43 +3,63 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { getProviderProfile } from '../services/providerService';
-// --- 1. IMPORTAMOS LA FUNCIÓN deleteEstablishment ---
 import { deleteEstablishment } from '../services/establishmentService'; 
 import { PlusIcon, PencilIcon, TrashIcon } from '@heroicons/react/24/solid';
 
-// El componente EstablishmentCard ya estaba correcto, no necesita cambios.
 const EstablishmentCard = ({ establishment, onDelete }) => (
   <div className="bg-white border border-gray-200 rounded-lg shadow-sm p-6 flex flex-col">
-    <div className="flex-grow">
+    {/* --- Sección de Información (sin cambios) --- */}
+    <div className="flex-grow mb-4">
       <h3 className="text-xl font-semibold text-gray-800">{establishment.nombre}</h3>
       <p className="text-gray-500 mt-2 text-sm">{establishment.direccion_completa}</p>
     </div>
     
-    <div className="mt-6 pt-4 border-t border-gray-200 flex justify-between items-center">
-      <Link 
-        to={`/provider/establishments/edit/${establishment.id}`}
-        className="inline-flex items-center text-sm font-medium text-gray-600 hover:text-indigo-600"
-      >
-        <PencilIcon className="h-4 w-4 mr-2" />
-        Editar
-      </Link>
+    {/* --- Sección de Acciones (Reorganizada) --- */}
+    <div className="mt-auto pt-4 border-t border-gray-200">
       
-    <div className="mt-4 flex justify-between items-center">
-        <Link to={`/provider/services?est_id=${establishment.id}`} className="text-sm font-medium text-gray-600 hover:text-gray-800">
-        Servicios
-      </Link>
-        <Link to={`/provider/availability?est_id=${establishment.id}`} className="text-sm font-medium text-indigo-600 hover:text-indigo-800">
-        Gestionar Horario →
-      </Link>
-    </div>
+      {/* Grupo de enlaces de gestión */}
+      <div className="flex justify-between items-center mb-4">
+        <Link 
+          to={`/dashboard/provider/services?est_id=${establishment.id}`} 
+          className="text-sm font-medium text-indigo-600 hover:text-indigo-800"
+        >
+          Servicios
+        </Link>
+        
+        <Link 
+          to={`/dashboard/provider/availability?est_id=${establishment.id}`} 
+          className="text-sm font-medium text-indigo-600 hover:text-indigo-800"
+        >
+          Horario
+        </Link>
+        
+        {/* --- NUEVO ENLACE A LA AGENDA --- */}
+        <Link 
+          to={`/dashboard/provider/appointments?est_id=${establishment.id}&name=${encodeURIComponent(establishment.nombre)}`} 
+          className="text-sm font-medium text-indigo-600 hover:text-indigo-800"
+        >
+          Agenda
+        </Link>
+      </div>
 
-      <button 
-        onClick={() => onDelete(establishment.id)}
-        className="inline-flex items-center text-sm font-medium text-red-600 hover:text-red-800"
-        title="Eliminar establecimiento"
-      >
-        <TrashIcon className="h-4 w-4" />
-      </button>
+      {/* Grupo de botones de edición/borrado */}
+      <div className="flex justify-between items-center">
+        <Link 
+          to={`/dashboard/provider/establishments/edit/${establishment.id}`}
+          className="inline-flex items-center text-sm font-medium text-gray-600 hover:text-indigo-600"
+        >
+          <PencilIcon className="h-4 w-4 mr-2" />
+          Editar
+        </Link>
+        
+        <button 
+          onClick={() => onDelete(establishment.id)}
+          className="inline-flex items-center text-sm font-medium text-red-600 hover:text-red-800"
+          title="Eliminar establecimiento"
+        >
+          <TrashIcon className="h-4 w-4" />
+        </button>
+      </div>
     </div>
   </div>
 );

--- a/frontend/src/pages/ProviderAppointments.jsx
+++ b/frontend/src/pages/ProviderAppointments.jsx
@@ -1,0 +1,106 @@
+// frontend/src/pages/ProviderAppointments.jsx
+
+import React, { useState, useEffect } from 'react';
+import { useSearchParams, Link } from 'react-router-dom';
+import { getAppointmentsForEstablishment } from '../services/establishmentService';
+
+// Componente para una sola cita en la agenda
+const AppointmentAgendaItem = ({ appointment }) => (
+  <div className="p-4 border-b border-gray-200 last:border-b-0">
+    <div className="flex justify-between items-center">
+        <div>
+            <p className="font-semibold text-gray-800">{appointment.service?.nombre || 'Servicio eliminado'}</p>
+            <p className="text-sm text-gray-600">
+                Cliente: {appointment.user?.first_name || 'Cliente'} {appointment.user?.last_name || ''}
+            </p>
+        </div>
+        <div className="text-right">
+            <p className="text-sm font-medium text-gray-800">
+                {new Date(appointment.start_time).toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' })}
+                {' - '}
+                {new Date(appointment.end_time).toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' })}
+            </p>
+            <p className="text-xs text-gray-500">
+                {new Date(appointment.start_time).toLocaleDateString('es-ES', { day: '2-digit', month: 'long', year: 'numeric' })}
+            </p>
+        </div>
+    </div>
+  </div>
+);
+
+
+const ProviderAppointments = () => {
+  const [appointments, setAppointments] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [searchParams] = useSearchParams();
+  
+  const establishmentId = searchParams.get('est_id');
+  const establishmentName = searchParams.get('name');
+
+  useEffect(() => {
+    if (!establishmentId) {
+      setError('No se ha especificado un establecimiento. Por favor, vuelve a la lista de establecimientos y selecciona uno.');
+      setLoading(false);
+      return;
+    }
+
+    const fetchAppointments = async () => {
+      try {
+        setLoading(true);
+        // --- 2. LLAMAMOS A LA API REAL ---
+        // Reemplazamos los datos de ejemplo con la llamada al servicio
+        const data = await getAppointmentsForEstablishment(establishmentId);
+        
+        // Ordenamos las citas por fecha (opcional, pero recomendado)
+        const sortedData = data.sort((a, b) => new Date(a.start_time) - new Date(b.start_time));
+        setAppointments(sortedData);
+
+      } catch (err) {
+        setError('No se pudieron cargar las citas para este establecimiento.');
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    
+    fetchAppointments();
+  }, [establishmentId]);
+
+  return (
+    <div className="page-wrapper">
+      <header className="page-header">
+        <h1>Agenda de Citas</h1>
+        {establishmentName ? (
+            <p>Mostrando citas para el establecimiento: <strong>{establishmentName}</strong></p>
+        ) : (
+            <p>Selecciona un establecimiento para ver su agenda.</p>
+        )}
+      </header>
+      
+      <div className="profile-card">
+        {loading && <p className="p-4 text-center">Cargando agenda...</p>}
+        {error && (
+            <div className="p-4 text-center">
+                <p className="error-message">{error}</p>
+                <Link to="/dashboard/provider/establishments" className="mt-4 inline-block text-indigo-600 hover:underline">
+                    Volver a mis establecimientos
+                </Link>
+            </div>
+        )}
+        
+        {!loading && !error && (
+          <div>
+            {appointments.length > 0 ? (
+              appointments.map(appt => <AppointmentAgendaItem key={appt.id} appointment={appt} />)
+            ) : (
+              <p className="p-4 text-center text-gray-500">No hay citas programadas para este establecimiento.</p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ProviderAppointments;

--- a/frontend/src/services/establishmentService.js
+++ b/frontend/src/services/establishmentService.js
@@ -63,7 +63,6 @@ export const getAvailableSlots = (establishmentId, serviceId, date) => {
   return apiClient(endpoint, 'GET');
 };
 
-// --- NUEVA FUNCIÓN AÑADIDA ---
 /**
  * Obtiene la lista de todos los establecimientos públicos para el directorio. (Público)
  * @returns {Promise<any>} Una lista de objetos de establecimiento.
@@ -71,4 +70,12 @@ export const getAvailableSlots = (establishmentId, serviceId, date) => {
 export const getAllPublicEstablishments = () => {
   // Apunta a la nueva ruta pública que acabamos de crear en el backend.
   return apiClient('/public/establishments', 'GET');
+};
+/**
+* Obtiene todas las citas para un establecimiento específico. (Protegido para Proveedor)
+* @param {string|number} establishmentId
+* @returns {Promise<any>}
+*/
+export const getAppointmentsForEstablishment = (establishmentId) => {
+ return apiClient(`/establishments/${establishmentId}/appointments`, 'GET');
 };


### PR DESCRIPTION
🧩 Resumen
Esta Pull Request incorpora una herramienta fundamental para los proveedores: la Agenda de Citas. Se ha creado una nueva página donde el proveedor puede visualizar todas las citas agendadas para cada uno de sus establecimientos, junto con los datos del cliente.

Esto proporciona al proveedor una vista clara y centralizada de su operativa diaria, facilitando la gestión eficiente del tiempo y los recursos.

📦 Cambios Detallados
🛠 Backend (/backend)
1. Enriquecimiento del modelo Appointment:

Archivo: app/models/scheduling.py

Cambio: El método Appointment.to_dict() ahora incluye la información del cliente (user.to_dict()).

Impacto: El endpoint GET /api/establishments/<id>/appointments devuelve todos los detalles relevantes de la cita, incluyendo el nombre del cliente, sin necesidad de llamadas adicionales desde el frontend.

💻 Frontend (/frontend)
1. Nueva Página: Agenda del Proveedor

Archivo: pages/ProviderAppointments.jsx

Ruta: /dashboard/provider/appointments

Funcionalidad:

Lee dinámicamente el establishment_id y el nombre del local desde la URL (?est_id=...&name=...).

Llama a getAppointmentsForEstablishment para cargar las citas del establecimiento.

Muestra las citas de forma clara y ordenada:

Nombre del servicio reservado

Nombre del cliente

Hora de la cita

Maneja correctamente:

Estado de carga

Errores

Casos sin citas programadas

2. Navegación desde la Tarjeta del Establecimiento

Archivo: pages/ManageEstablishments.jsx

Cambio: El componente EstablishmentCard ahora incluye un botón “Ver Agenda”.

Impacto: Permite al proveedor acceder directamente a la agenda de un establecimiento desde la lista de sus locales.

3. Servicio de API actualizado

Archivo: services/establishmentService.js

Función añadida: getAppointmentsForEstablishment()

Función: Realiza la petición al nuevo endpoint con el establishment_id.

4. Rutas y Enlaces

Se ha añadido la nueva ruta a App.jsx.

También se ha incorporado el enlace en el menú lateral del DashboardLayout.jsx, aunque el acceso principal es desde la tarjeta del establecimiento.

🧪 Cómo Probar la Funcionalidad
✅ Requisito previo
Asegúrate de tener al menos una cita agendada en un establecimiento gestionado por tu usuario proveedor.

1. Acceder a la Agenda
URL: http://localhost:5173/dashboard/provider/establishments

Acción: Inicia sesión como proveedor y entra en la sección Establecimientos.

Haz clic en el botón "Ver Agenda" del establecimiento que tiene citas.

2. Visualizar las Citas
Ruta destino: /dashboard/provider/appointments?est_id=...

Resultado esperado:

El título de la página muestra el nombre del establecimiento (ej. “Mostrando citas para: Carla Nails & Beauty”).

Se renderiza una lista con las citas programadas, mostrando:

Nombre del servicio

Nombre del cliente

Fecha y hora

3. Comprobar comportamiento sin citas
Acción: Entra a la agenda de un establecimiento que no tenga citas.

Resultado esperado: Se muestra un mensaje como “No hay citas programadas para este establecimiento”.

