### PR TITLE
feat: Implement email notifications for appointment confirmation

### DIFF
--- a/backend/app/routes/appointment.py
+++ b/backend/app/routes/appointment.py
@@ -5,6 +5,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 from app import db
 from app.models import Appointment, Service, User
 from datetime import datetime, timedelta, timezone
+from .email_service import send_appointment_confirmation_emails
 
 appointment_bp = Blueprint('appointment', __name__)
 
@@ -110,7 +111,14 @@ def create_appointment():
     )
     db.session.add(new_appointment)
     db.session.commit()
-    return jsonify(new_appointment.to_dict()), 201
+    try:
+        send_appointment_confirmation_emails(new_appointment)
+    except Exception as e:
+        # Si el envío de email falla, no rompemos la petición. Solo lo registramos.
+        current_app.logger.error(f"La cita {new_appointment.id} se creó, pero falló el envío de emails: {e}", exc_info=True)
+
+    # Devolvemos la respuesta al frontend como siempre.
+    return jsonify(new_appointment.to_dict()), 201    
 
 @appointment_bp.route('appointments/client', methods=['GET'])
 @jwt_required()

--- a/backend/app/routes/email_service.py
+++ b/backend/app/routes/email_service.py
@@ -1,6 +1,7 @@
 from flask_mail import Message
 from flask import current_app, url_for, Blueprint
 from app import mail
+from zoneinfo import ZoneInfo
 
 
 bp = Blueprint('email', __name__, url_prefix='/email')
@@ -76,3 +77,67 @@ def send_password_reset_email(user, token):
         body=f"Hola {nombre}, restablece tu contraseña aquí: {reset_link}"
     )
 
+def format_datetime_for_email(dt_utc, timezone_str):
+    """Formatea una fecha/hora UTC a una zona horaria específica y legible."""
+    try:
+        provider_tz = ZoneInfo(timezone_str)
+        dt_local = dt_utc.astimezone(provider_tz)
+        # Formato amigable: "viernes, 5 de julio de 2024 a las 10:30"
+        return dt_local.strftime('%A, %d de %B de %Y a las %H:%M')
+    except:
+        # Si falla, devuelve un formato simple en UTC
+        return dt_utc.strftime('%Y-%m-%d %H:%M:%S UTC')
+
+def send_appointment_confirmation_emails(appointment):
+    """
+    Envía correos de confirmación tanto al cliente como al proveedor.
+    Esta función orquesta el envío de los dos correos.
+    """
+    if not appointment:
+        return False
+
+    client = appointment.user
+    service = appointment.service
+    establishment = service.establishment
+    provider_user = establishment.provider.user # El usuario asociado al proveedor
+
+    if not all([client, service, establishment, provider_user]):
+        current_app.logger.error(f"Faltan datos para enviar email de confirmación de cita {appointment.id}")
+        return False
+        
+    provider_timezone = establishment.provider.timezone or 'UTC'
+    formatted_start_time = format_datetime_for_email(appointment.start_time, provider_timezone)
+
+    # 1. Enviar correo al Cliente
+    client_subject = f"✅ Cita Confirmada: {service.nombre} en {establishment.nombre}"
+    client_html = f"""
+        <p>Hola <strong>{client.first_name or 'tú'}</strong>,</p>
+        <p>Tu cita ha sido confirmada con éxito. Aquí tienes los detalles:</p>
+        <ul>
+            <li><strong>Establecimiento:</strong> {establishment.nombre}</li>
+            <li><strong>Dirección:</strong> {establishment.direccion_completa}</li>
+            <li><strong>Servicio:</strong> {service.nombre}</li>
+            <li><strong>Día y Hora:</strong> {formatted_start_time}</li>
+            <li><strong>Precio:</strong> {appointment.precio_final} €</li>
+        </ul>
+        <p>¡Te esperamos!</p>
+    """
+    send_email(client_subject, [client.email], html=client_html)
+
+    # 2. Enviar correo al Proveedor (a su email de contacto si existe, si no al de la cuenta)
+    provider_email = establishment.provider.email_contacto or provider_user.email
+    provider_subject = f"🔔 Nueva Cita Reservada: {service.nombre} a las {formatted_start_time}"
+    provider_html = f"""
+        <p>¡Hola <strong>{establishment.provider.nombre_comercial}</strong>!</p>
+        <p>Has recibido una nueva reserva:</p>
+        <ul>
+            <li><strong>Cliente:</strong> {client.first_name or ''} {client.last_name or ''} ({client.email})</li>
+            <li><strong>Servicio:</strong> {service.nombre}</li>
+            <li><strong>Día y Hora:</strong> {formatted_start_time}</li>
+        </ul>
+        {f'<p><strong>Notas del cliente:</strong> {appointment.notas_cliente}</p>' if appointment.notas_cliente else ''}
+        <p>La cita ha sido añadida a tu agenda.</p>
+    """
+    send_email(provider_subject, [provider_email], html=provider_html)
+    
+    return True


### PR DESCRIPTION
🧩 Resumen
Esta Pull Request introduce un componente clave para mejorar la experiencia del usuario y la profesionalidad de la plataforma: las notificaciones por correo electrónico tras confirmar una cita.

A partir de ahora, cuando un cliente finaliza una reserva, el sistema envía automáticamente correos de confirmación tanto al cliente como al proveedor del establecimiento. Esto garantiza una comunicación clara, instantánea y confiable entre ambas partes.

📦 Cambios Detallados
🛠 Backend (/backend)
1. Nuevo módulo de notificaciones de citas

Archivo: app/routes/email_service.py

Función principal: send_appointment_confirmation_emails(appointment)

Responsabilidades:

Recupera todos los datos necesarios (cliente, proveedor, servicio, establecimiento) a partir del objeto appointment.

Construye un email personalizado para el cliente con:

Servicio reservado

Establecimiento y dirección

Fecha y hora local del proveedor

Precio

Construye un email para el proveedor con:

Datos del cliente

Servicio solicitado

Fecha y hora

Manejando correctamente las zonas horarias para mostrar la hora local con claridad.

2. Integración en el flujo de creación de citas

Archivo: app/routes/appointment.py

Ruta afectada: POST /api/appointments

Funcionalidad:

Una vez que la cita se guarda con éxito (db.session.commit()), se ejecuta send_appointment_confirmation_emails.

El envío de correo está encapsulado en un bloque try...except, garantizando que:

Si el correo falla, la cita igualmente se crea y se devuelve una respuesta exitosa a la API.

Se evita interrumpir la experiencia del usuario final.

✅ Checklist de Funcionalidad
 Tras crear una cita, se activa automáticamente el envío de correos electrónicos.

 El cliente recibe un email de confirmación con todos los detalles.

 El proveedor recibe una notificación con los datos de la nueva cita y del cliente.

 Los horarios en ambos correos respetan la zona horaria del proveedor.

 Si el servicio de correo falla, la cita sigue registrándose correctamente.

🧪 Cómo Probar
🔧 Requisito previo
Tener un cliente y un proveedor registrados con correos válidos.

Tener MailHog ejecutándose en http://localhost:8025 para capturar los correos enviados.

1. Reservar una cita
Accede a la app: http://localhost:5173/

Selecciona un establecimiento público.

Elige un servicio, fecha y hora.

Inicia sesión como cliente y confirma la cita.

2. Verificar los correos
Abre MailHog en http://localhost:8025.

Resultado esperado:

Deberían generarse dos correos nuevos:

Uno dirigido al cliente.

Otro al proveedor.

Ambos deben mostrar correctamente los datos de la cita (servicio, hora, lugar, precio, etc.).

