### PR TITLE
Webhook metrics & hardening: idempotency guard, WA signature check, per-sender rate limit, Redis-backed limiter, admin metrics endpoint

### DIFF
--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -19,7 +19,8 @@ from .staff_availability import staff_availability_bp
 from .whatsapp_invite import bp as whatsapp_invite_bp
 from .whatsapp import bp as bp_whatsapp_webhook
 from .admin_metrics import bp as admin_metrics_bp
-from .admin_metrics_otp import bp as admin_metrics_otp_bp 
+from .admin_metrics_otp import bp as admin_metrics_otp_bp
+from .admin_metrics_webhook import bp as bp_admin_metrics_webhook
 
 
 # Registramos todos los blueprints
@@ -38,3 +39,4 @@ bp_api.register_blueprint(whatsapp_invite_bp, url_prefix='/whatsapp')
 bp_api.register_blueprint(bp_whatsapp_webhook)
 bp_api.register_blueprint(admin_metrics_bp)
 bp_api.register_blueprint(admin_metrics_otp_bp)
+bp_api.register_blueprint(bp_admin_metrics_webhook)

--- a/backend/app/routes/admin_metrics_webhook.py
+++ b/backend/app/routes/admin_metrics_webhook.py
@@ -1,0 +1,159 @@
+# backend/app/routes/admin_metrics_webhook.py
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from sqlalchemy import func, desc
+from datetime import datetime, timedelta, timezone
+
+from app import db
+from app.models import User
+from app.models.webhook_event import WebhookEvent
+
+bp = Blueprint("admin_metrics_webhook", __name__)
+
+@bp.get("/admin/metrics/webhook")
+@jwt_required()
+def webhook_metrics():
+    """
+    Métricas de eventos del webhook de WhatsApp en una ventana temporal (por defecto 60 min).
+    - totals_by_type: conteo por event_type
+    - recent.total_events / unique_senders
+    - duplicates_guard: número de duplicados detectados (guard con message_id IS NULL)
+    - invalid_signatures: número de firmas inválidas (event_type='webhook' y signature_valid=false)
+    - top_senders: top N emisores por número de eventos
+    Params:
+      minutes (int) ventana, default=60
+      top (int) top emisores, default=5
+      debug=1 -> incluye una muestra de eventos recientes
+    Requiere rol provider o admin.
+    """
+    # Auth y rol
+    uid = int(get_jwt_identity())
+    user = User.query.get(uid)
+    if not user or user.role not in ("provider", "admin"):
+        return jsonify({"msg": "No autorizado"}), 403
+
+    # Ventana
+    try:
+        window_minutes = int(request.args.get("minutes", "60"))
+    except Exception:
+        window_minutes = 60
+    window_minutes = max(1, min(window_minutes, 24 * 60))  # clamp 1..1440
+
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(minutes=window_minutes)
+
+    # Totales por tipo
+    totals_rows = (
+        db.session.query(
+            WebhookEvent.event_type.label("event_type"),
+            func.count().label("cnt")
+        )
+        .filter(WebhookEvent.created_at >= since)
+        .group_by(WebhookEvent.event_type)
+        .order_by(WebhookEvent.event_type)
+        .all()
+    )
+    totals_by_type = [
+        {"event_type": r.event_type, "count": int(r.cnt)} for r in totals_rows
+    ]
+
+    # Eventos recientes y emisores únicos
+    total_events = (
+        db.session.query(func.count())
+        .select_from(WebhookEvent)
+        .filter(WebhookEvent.created_at >= since)
+        .scalar()
+    ) or 0
+
+    unique_senders = (
+        db.session.query(func.count(func.distinct(WebhookEvent.from_msisdn)))
+        .filter(WebhookEvent.created_at >= since, WebhookEvent.from_msisdn.isnot(None))
+        .scalar()
+    ) or 0
+
+    # Duplicados robustos: guards sin message_id
+    duplicates_guard = (
+        db.session.query(func.count())
+        .select_from(WebhookEvent)
+        .filter(
+            WebhookEvent.created_at >= since,
+            WebhookEvent.event_type == "guard",
+            WebhookEvent.message_id.is_(None),
+        )
+        .scalar()
+    ) or 0
+
+    # Firmas inválidas
+    invalid_signatures = (
+        db.session.query(func.count())
+        .select_from(WebhookEvent)
+        .filter(
+            WebhookEvent.created_at >= since,
+            WebhookEvent.event_type == "webhook",
+            WebhookEvent.signature_valid.is_(False),
+        )
+        .scalar()
+    ) or 0
+
+    # Top emisores
+    try:
+        top_n = int(request.args.get("top", "5"))
+    except Exception:
+        top_n = 5
+    top_n = max(1, min(top_n, 50))
+
+    top_rows = (
+        db.session.query(
+            WebhookEvent.from_msisdn.label("sender"),
+            func.count().label("events"),
+        )
+        .filter(WebhookEvent.created_at >= since, WebhookEvent.from_msisdn.isnot(None))
+        .group_by(WebhookEvent.from_msisdn)
+        .order_by(desc("events"))
+        .limit(top_n)
+        .all()
+    )
+    top_senders = [{"from": r.sender, "events": int(r.events)} for r in top_rows]
+
+    resp = {
+        "window_minutes": window_minutes,
+        "since": since.isoformat(),
+        "totals_by_type": totals_by_type,
+        "recent": {
+            "total_events": int(total_events),
+            "unique_senders": int(unique_senders),
+        },
+        "duplicates_guard": int(duplicates_guard),
+        "invalid_signatures": int(invalid_signatures),
+        "top_senders": top_senders,
+    }
+
+    # Modo debug opcional: muestra una muestra de eventos recientes
+    if request.args.get("debug") == "1":
+        sample_rows = (
+            db.session.query(
+                WebhookEvent.event_type,
+                WebhookEvent.message_id,
+                WebhookEvent.from_msisdn,
+                WebhookEvent.signature_valid,
+                WebhookEvent.error_reason,
+                WebhookEvent.created_at,
+            )
+            .filter(WebhookEvent.created_at >= since)
+            .order_by(desc(WebhookEvent.created_at))
+            .limit(20)
+            .all()
+        )
+        resp["sample"] = [
+            {
+                "event_type": r.event_type,
+                "message_id": r.message_id,
+                "from_msisdn": r.from_msisdn,
+                "signature_valid": r.signature_valid,
+                "error_reason": r.error_reason,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in sample_rows
+        ]
+
+    return jsonify(resp), 200

--- a/backend/app/routes/whatsapp.py
+++ b/backend/app/routes/whatsapp.py
@@ -109,13 +109,14 @@ def receive_message():
                     invite_token=None,
                     sent_ok=False,
                     signature_valid=False,
+                    error_reason="invalid_signature",
                 )
                 db.session.add(ev)
                 db.session.commit()
         except Exception:
             db.session.rollback()
 
-        # Rechazamos para no aceptar cargas sin firma válida
+        # Rechazamos para no aceptar cargas sin firma válida (puedes devolver 200 si prefieres evitar reintentos)
         return jsonify({"status": "invalid_signature"}), 403
 
     payload = request.get_json(silent=True) or {}
@@ -131,7 +132,7 @@ def receive_message():
                     message_id = msg.get("id")
                     from_number = msg.get("from")  # MSISDN (sin '+')
 
-                    # --- Idempotencia atómica (insert-first guard) ---
+                    # --- Idempotencia atómica (insert-first guard con UNIQUE(message_id)) ---
                     if WebhookEvent and message_id:
                         try:
                             ev_guard = WebhookEvent(
@@ -142,13 +143,30 @@ def receive_message():
                                 invite_token=None,
                                 sent_ok=False,
                                 signature_valid=sig_ok,
+                                error_reason=None,
                             )
                             db.session.add(ev_guard)
                             db.session.commit()
                         except IntegrityError:
+                            # Ya procesado: registra un 'guard' sin message_id para contar el duplicado y sigue
                             db.session.rollback()
-                            current_app.logger.info(f"[WhatsApp] Duplicado message_id={message_id}, ignorando.")
-                            continue  # ya procesado antes
+                            try:
+                                dup = WebhookEvent(
+                                    event_type="guard",
+                                    message_id=None,  # sin ID para no violar UNIQUE
+                                    from_msisdn=from_number,
+                                    keyword_detected=None,
+                                    invite_token=None,
+                                    sent_ok=False,
+                                    signature_valid=sig_ok,
+                                    error_reason="duplicate_message",
+                                )
+                                db.session.add(dup)
+                                db.session.commit()
+                            except Exception:
+                                db.session.rollback()
+                            current_app.logger.info(f"[WhatsApp] Guard: duplicado message_id={message_id}, ignorando.")
+                            continue  # no procesamos este mensaje otra vez
 
                     # "text" puede venir como objeto {"body": "..."} o no venir
                     text_field = msg.get("text")
@@ -181,6 +199,7 @@ def receive_message():
                                     "keyword_detected": False,
                                     "invite_token": None,
                                     "sent_ok": False,
+                                    "error_reason": "no_keyword",
                                 })
                                 db.session.commit()
                         except Exception:
@@ -230,6 +249,7 @@ def receive_message():
                                     "keyword_detected": True,
                                     "invite_token": inv.token,
                                     "sent_ok": sent_ok,
+                                    "error_reason": None,
                                 })
                                 db.session.commit()
                         except Exception:
@@ -266,6 +286,7 @@ def receive_message():
                                     "keyword_detected": keyword,
                                     "invite_token": None,
                                     "sent_ok": False,
+                                    "error_reason": str(e)[:255],
                                 })
                                 db.session.commit()
                         except Exception:


### PR DESCRIPTION
Resumen

Refactor del webhook de WhatsApp:

Idempotencia insert-first con WebhookEvent.message_id (UNIQUE).

Verificación HMAC (X-Hub-Signature-256) con WHATSAPP_APP_SECRET.

Respuesta saliente a WA usando to sin ‘+’.

Rate limiting: 60/min global (IP Meta) + 5/min por emisor MSISDN.

Nuevo endpoint admin: GET /api/admin/metrics/webhook

Totales por event_type (guard, message, webhook, error)

duplicates_guard (reintentos/duplicados protegidos por UNIQUE)

invalid_signatures

Ventana temporal configurable ?minutes=60

Top emisores ?top=5

Limiter persistente con Redis para que no se reinicie al recargar el contenedor.

Archivos clave

backend/app/routes/whatsapp.py → guard atómico + firma HMAC + RL emisor

backend/app/models/webhook_event.py → v2: event_type, flags, índices

backend/app/routes/admin_metrics_webhook.py → nuevo endpoint

migrations/versions/a2d5152c6124_*.py → migración compatible con datos existentes

backend/app/__init__.py → ProxyFix, headers RL, RATELIMIT_STORAGE_URI

docker-compose.yml → servicio redis y depends_on

backend/requirements.txt → flask-limiter, redis

ENV esperado

WHATSAPP_SEND_ENABLED=true
WHATSAPP_ACCESS_TOKEN=*** (no commitear)
WHATSAPP_PHONE_NUMBER_ID=710558738814354
WHATSAPP_APP_SECRET=***
WHATSAPP_VERIFY_TOKEN=mi_token_webhook_seguro
WHATSAPP_REQUIRE_VALID_SIGNATURE=true
BOOKING_KEYWORDS=RESERVAR,RESERVA,CITA
WHATSAPP_DEFAULT_NEXT=/
ECHO_WEBHOOK_INVITE_URL=false

RATELIMIT_STORAGE_URI=redis://redis:6379/0


Migración

webhook_events v2: event_type + flags + indices

añade event_type NOT NULL DEFAULT 'message'

signature_valid (bool)

message_id → String(128) + índice UNIQUE

índice compuesto ix_webhook_events_sender_created (from_msisdn, created_at)

Pruebas manuales (resumen)

Firma válida/ inválida → invalid_signatures sube con inválida.

Duplicados por message_id → duplicates_guard sube.

Carga por varios emisores → top_senders se rellena.

Rate limit por emisor → 429 a partir del 6º en 1 min.

Riesgos y mitigación

Si WHATSAPP_APP_SECRET no está, el webhook rechaza (403). Documentado en .env.example.

Si Redis cae, Limiter puede volver a memory:// (solo dev); en prod mantener Redis.

Post-merge

Verificar .env en entorno de despliegue (no subir secrets).

Rotar WHATSAPP_ACCESS_TOKEN cuando sea necesario.

(Opcional) Añadir UI en admin para ver estas métricas.