### PR TITLE
auth: return refresh_token on login and add /api/auth/refresh; configurable expirations

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -11,6 +11,8 @@ DB_NAME=citas_online_db
 SECRET_KEY=una_clave_secreta_segura
 JWT_SECRET_KEY=otra_clave_jwt_segura      # <- única fuente para JWT
 # JWT_SECRET (ELIMINADO): era duplicado / no se usa
+JWT_ACCESS_TOKEN_EXPIRES=3600        # 1h (en segundos)
+JWT_REFRESH_TOKEN_EXPIRES=1209600    # 14d (en segundos)
 
 # --- Mailhog ---
 MAIL_SERVER=mailhog

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -2,6 +2,7 @@
 from flask import Blueprint, jsonify, request, current_app, redirect
 from flask_jwt_extended import (
     create_access_token,
+    create_refresh_token,
     jwt_required,
     get_jwt_identity,
 )
@@ -167,11 +168,17 @@ def login():
         if not user or not user.check_password(password):
             return jsonify({"msg": "Credenciales incorrectas"}), 401
 
+        # ⬇️ Generamos ambos tokens
         access_token = create_access_token(identity=str(user.user_id))
+        refresh_token = create_refresh_token(identity=str(user.user_id))
+
+        # Notificación opcional
         send_login_notification(user)
 
+        # ⬇️ Devolvemos también el refresh_token
         return jsonify({
             "access_token": access_token,
+            "refresh_token": refresh_token,
             "user_id": user.user_id,
             "role": user.role
         }), 200
@@ -179,6 +186,14 @@ def login():
     except Exception as e:
         current_app.logger.error(f"Error en login: {e}", exc_info=True)
         return jsonify({"msg": "Error interno del servidor", "error_details": str(e)}), 500
+    
+@bp.post("/refresh")
+@jwt_required(refresh=True)
+def refresh_token():
+    """Devuelve un nuevo access_token usando el refresh_token."""
+    identity = get_jwt_identity()
+    access = create_access_token(identity=identity)
+    return jsonify(access_token=access), 200
 
 @bp.route('/protected', methods=['GET'])
 @jwt_required()
@@ -273,8 +288,8 @@ def google_oauth_login():
 
         email = idinfo.get('email')
         first_name = idinfo.get('given_name', '')
-        last_name = idinfo.get('family_name', '')
-        picture = idinfo.get('picture', '')
+        last_name  = idinfo.get('family_name', '')
+        picture    = idinfo.get('picture', '')
 
         if not email:
             return jsonify({"msg": "No se pudo obtener el email del token"}), 400
@@ -295,11 +310,13 @@ def google_oauth_login():
             db.session.add(user)
             db.session.commit()
 
-        access_token = create_access_token(identity=str(user.user_id))
+        access_token  = create_access_token(identity=str(user.user_id))
+        refresh_token = create_refresh_token(identity=str(user.user_id))
         send_login_notification(user)
 
         return jsonify({
             "access_token": access_token,
+            "refresh_token": refresh_token,
             "user_id": user.user_id,
             "role": user.role
         }), 200
@@ -310,6 +327,7 @@ def google_oauth_login():
     except Exception as e:
         current_app.logger.error(f"Error en login social: {e}", exc_info=True)
         return jsonify({"msg": "Error en login social", "error": str(e)}), 500
+
 
 @bp.route('/whatsapp/init', methods=['POST'])
 @jwt_required()
@@ -365,7 +383,7 @@ def magic():
     """
     Valida el token mágico y emite un access_token normal.
     Query: /auth/magic?token=...
-    Respuesta: { "access_token": "...", "user_id": ..., "role": "...", "profile_complete": bool }
+    Respuesta: { "access_token": "...", "refresh_token": "...", ... }
     """
     token = (request.args.get("token") or "").strip()
     if not token:
@@ -379,14 +397,17 @@ def magic():
         current_app.logger.error(f"Error validando magic link: {e}", exc_info=True)
         return jsonify({"msg": "Error interno validando enlace"}), 500
 
-    access_token = create_access_token(identity=str(user.user_id))
+    access_token  = create_access_token(identity=str(user.user_id))
+    refresh_token = create_refresh_token(identity=str(user.user_id))
 
     return jsonify({
         "access_token": access_token,
+        "refresh_token": refresh_token,
         "user_id": user.user_id,
         "role": user.role,
         "profile_complete": _profile_complete(user)
     }), 200
+
 
 @bp.route('/email/resend-verification', methods=['POST'], endpoint='email_resend_verification')
 @jwt_required()
@@ -442,14 +463,16 @@ def phone_request_otp():
 def phone_verify_otp():
     data = request.get_json(silent=True) or {}
     phone = (data.get("phone_number") or "").strip()
-    code = (data.get("code") or "").strip()
+    code  = (data.get("code") or "").strip()
     if not phone or not code:
         return jsonify({"msg": "phone_number y code requeridos"}), 400
     try:
         user = otp_verify(phone, code, purpose="login")
-        access_token = create_access_token(identity=str(user.user_id))
+        access_token  = create_access_token(identity=str(user.user_id))
+        refresh_token = create_refresh_token(identity=str(user.user_id))
         return jsonify({
             "access_token": access_token,
+            "refresh_token": refresh_token,
             "user_id": user.user_id,
             "role": user.role,
             "profile_complete": _profile_complete(user),

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,10 +1,15 @@
 # backend/config.py
 import os
+from datetime import timedelta 
 
 class Config:
     SECRET_KEY = os.environ.get('SECRET_KEY') or '0g>G#hwr69RxTc#qt8'
     JWT_SECRET_KEY = os.environ.get('JWT_SECRET_KEY') or 'EstaEsMiClaveDePruebaFinalConSoloLetrasYNumerosABCDEF123456'
-    JWT_ACCESS_TOKEN_EXPIRES = 3600
+    _ACCESS_SEC  = int(os.environ.get('JWT_ACCESS_TOKEN_EXPIRES', 3600))
+    _REFRESH_SEC = int(os.environ.get('JWT_REFRESH_TOKEN_EXPIRES', 2592000))  # 30 días
+
+    JWT_ACCESS_TOKEN_EXPIRES  = timedelta(seconds=_ACCESS_SEC)
+    JWT_REFRESH_TOKEN_EXPIRES = timedelta(seconds=_REFRESH_SEC)
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
     SQLALCHEMY_ENGINE_OPTIONS = {

--- a/frontend/src/api/adminMetrics.ts
+++ b/frontend/src/api/adminMetrics.ts
@@ -39,8 +39,17 @@ export type WebhookMetrics = {
 // ---------- Config ----------
 const API_BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:5001/api";
 
-// Lee token desde cualquiera de las dos claves que usamos en la app
-function getToken(): string | null {
+// Sincroniza access_token por compatibilidad (accessToken -> access_token)
+export function ensureTokenSync() {
+  try {
+    const at = localStorage.getItem("accessToken");
+    if (at && localStorage.getItem("access_token") !== at) {
+      localStorage.setItem("access_token", at);
+    }
+  } catch {}
+}
+
+function getAccessToken(): string | null {
   const keys = ["access_token", "accessToken"];
   for (const k of keys) {
     const v = localStorage.getItem(k);
@@ -49,50 +58,78 @@ function getToken(): string | null {
   return null;
 }
 
-/**
- * Sincroniza las dos claves de token en localStorage:
- * - Si existe en una y no en la otra, lo copia.
- * - Si existen ambos y difieren, prioriza `accessToken`.
- * Devuelve true si hizo algún cambio; además dispara un `storage` para que React
- * se entere sin recargar.
- */
-export function ensureTokenSync(): boolean {
-  try {
-    const t1 = localStorage.getItem("accessToken");
-    const t2 = localStorage.getItem("access_token");
-    const chosen = t1 || t2;
-    if (!chosen) return false;
+function getRefreshToken(): string | null {
+  return localStorage.getItem("refresh_token");
+}
 
-    let changed = false;
-    if (t2 !== chosen) {
-      localStorage.setItem("access_token", chosen);
-      changed = true;
+function setAccessToken(token: string) {
+  localStorage.setItem("access_token", token);
+  localStorage.setItem("accessToken", token);
+}
+
+function clearTokens() {
+  localStorage.removeItem("access_token");
+  localStorage.removeItem("accessToken");
+  localStorage.removeItem("refresh_token");
+  localStorage.removeItem("userRole");
+}
+
+// ---------- Refresh helper ----------
+async function tryRefreshAccessToken(): Promise<string | null> {
+  const rt = getRefreshToken();
+  if (!rt) return null;
+
+  const res = await fetch(`${API_BASE}/auth/refresh`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${rt}`,
+    },
+    credentials: "include",
+  });
+
+  if (!res.ok) return null;
+
+  try {
+    const data = await res.json();
+    const at = data?.access_token;
+    if (at) {
+      setAccessToken(at);
+      return at;
     }
-    if (t1 !== chosen) {
-      localStorage.setItem("accessToken", chosen);
-      changed = true;
-    }
-    if (changed) {
-      // Nota: el StorageEvent nativo no se dispara en la misma pestaña,
-      // pero este Event simple sí activa nuestros listeners.
-      window.dispatchEvent(new Event("storage"));
-    }
-    return changed;
-  } catch {
-    return false;
-  }
+  } catch {}
+  return null;
 }
 
 // ---------- Helper fetch ----------
 async function apiGet<T>(path: string): Promise<T> {
-  const token = getToken();
-  const res = await fetch(`${API_BASE}${path}`, {
-    headers: {
-      "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-    credentials: "include",
-  });
+  const doFetch = async () => {
+    const token = getAccessToken();
+    return fetch(`${API_BASE}${path}`, {
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      credentials: "include",
+    });
+  };
+
+  let res = await doFetch();
+
+  // Si caducó, intentamos refresh y reintentamos UNA vez
+  if (res.status === 401) {
+    const refreshed = await tryRefreshAccessToken();
+    if (refreshed) {
+      res = await doFetch();
+    } else {
+      // refresh inválido/caducado: limpiamos y mandamos a login
+      clearTokens();
+      const next = encodeURIComponent(window.location.pathname + window.location.search);
+      window.location.replace(`/login?next=${next}`);
+      // y lanzamos el error para cortar la ejecución actual
+      throw new Error(`GET ${path} 401: Token expired`);
+    }
+  }
 
   if (!res.ok) {
     let detail = "";
@@ -102,9 +139,7 @@ async function apiGet<T>(path: string): Promise<T> {
     } catch {
       try {
         detail = await res.text();
-      } catch {
-        detail = "";
-      }
+      } catch {}
     }
     throw new Error(`GET ${path} ${res.status}: ${detail || res.statusText}`);
   }
@@ -113,14 +148,11 @@ async function apiGet<T>(path: string): Promise<T> {
 }
 
 // ---------- Endpoints ----------
-export const fetchWhatsAppMetrics = (days: number = 14) =>
+export const fetchWhatsAppMetrics = (days = 14) =>
   apiGet<WhatsAppMetrics>(`/admin/metrics/whatsapp?days=${Number(days)}`);
 
-export const fetchOTPMetrics = (days: number = 14) =>
+export const fetchOTPMetrics = (days = 14) =>
   apiGet<OTPMetrics>(`/admin/metrics/otp?days=${Number(days)}`);
 
-export const fetchWebhookMetrics = (minutes: number = 60, top: number = 5) => {
-  const m = Number(minutes);
-  const t = Number(top);
-  return apiGet<WebhookMetrics>(`/admin/metrics/webhook?minutes=${m}&top=${t}`);
-};
+export const fetchWebhookMetrics = (minutes = 60, top = 5) =>
+  apiGet<WebhookMetrics>(`/admin/metrics/webhook?minutes=${Number(minutes)}&top=${Number(top)}`);

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -5,20 +5,46 @@ import toast from 'react-hot-toast';
 import { loginUser, loginWithGoogle } from '../services/authService';
 import GoogleLoginComponent from "./GoogleLoginComponent";
 import Button from '../components/ui/Button';
-import Input from '../components/ui/Input'; 
+import Input from '../components/ui/Input';
+
+// Util: decodifica el JWT (solo header.payload)
+function decodeJwt(token) {
+  if (!token) return null;
+  const parts = token.split('.');
+  if (parts.length < 2) return null;
+  try {
+    const json = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
+    return json || null;
+  } catch {
+    return null;
+  }
+}
 
 function Login({ onLogin }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
   const navigate = useNavigate();
   const location = useLocation();
 
-  const persistAuth = (accessToken, role) => {
-    // Guardamos en ambas claves para compatibilidad con /admin/metrics
-    localStorage.setItem('access_token', accessToken);
-    localStorage.setItem('accessToken', accessToken);
+  const persistAuth = (accessToken, refreshToken, role) => {
+    // Guardamos en ambas claves por compatibilidad con /admin/metrics
+    if (accessToken) {
+      localStorage.setItem('access_token', accessToken);
+      localStorage.setItem('accessToken', accessToken);
+      const a = decodeJwt(accessToken);
+      if (a?.exp) localStorage.setItem('access_exp', String(a.exp));
+    }
+    if (refreshToken) {
+      localStorage.setItem('refresh_token', refreshToken);
+      localStorage.setItem('refreshToken', refreshToken);
+      const r = decodeJwt(refreshToken);
+      if (r?.exp) localStorage.setItem('refresh_exp', String(r.exp));
+    }
     localStorage.setItem('userRole', role || '');
-    // Y notificamos al contenedor (App) para que actualice estado
+
+    // Notifica a App para que actualice su estado
     if (typeof onLogin === 'function') onLogin(accessToken, role);
   };
 
@@ -29,24 +55,32 @@ function Login({ onLogin }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setSubmitting(true);
     try {
+      // IMPORTANTE: tu backend ahora devuelve { access_token, refresh_token, role, ... }
       const data = await loginUser(email, password);
-      persistAuth(data.access_token, data.role);
+      persistAuth(data.access_token, data.refresh_token, data.role);
       toast.success('¡Bienvenido/a de nuevo!');
       redirectAfterLogin();
     } catch (error) {
       toast.error(error.message || "Error al iniciar sesión.");
+    } finally {
+      setSubmitting(false);
     }
   };
 
   const handleGoogleLogin = async (googleToken) => {
+    setSubmitting(true);
     try {
+      // Asegúrate de que /login/google también devuelva refresh_token
       const data = await loginWithGoogle(googleToken);
-      persistAuth(data.access_token, data.role);
+      persistAuth(data.access_token, data.refresh_token, data.role);
       toast.success('¡Bienvenido/a de nuevo!');
       redirectAfterLogin();
     } catch (error) {
       toast.error(error.message || "Error en el inicio con Google.");
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -78,6 +112,7 @@ function Login({ onLogin }) {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
+              disabled={submitting}
             />
             <Input
               type="password"
@@ -85,9 +120,10 @@ function Login({ onLogin }) {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
+              disabled={submitting}
             />
-            <Button type="submit" variant="primary" className="w-full">
-              Entrar
+            <Button type="submit" variant="primary" className="w-full" disabled={submitting}>
+              {submitting ? 'Entrando…' : 'Entrar'}
             </Button>
           </form>
 

--- a/frontend/src/pages/LoginPhone.jsx
+++ b/frontend/src/pages/LoginPhone.jsx
@@ -7,6 +7,19 @@ import Input from '../components/ui/Input';
 import Button from '../components/ui/Button';
 import { getLastPhone, setLastPhone } from '../utils/phoneMemory';
 
+// Util: decodifica el JWT (solo payload)
+function decodeJwt(token) {
+  if (!token) return null;
+  const parts = token.split('.');
+  if (parts.length < 2) return null;
+  try {
+    const json = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
+    return json || null;
+  } catch {
+    return null;
+  }
+}
+
 export default function LoginPhone() {
   const [step, setStep] = useState('phone'); // 'phone' | 'code'
   const [phone, setPhone] = useState('');
@@ -20,6 +33,23 @@ export default function LoginPhone() {
   const autoSend = searchParams.get('send') === '1';
 
   const lastPhone = useMemo(() => getLastPhone() || '', []);
+
+  // Guarda tokens/role en localStorage (ambas claves para compatibilidad)
+  const persistAuth = (accessToken, refreshToken, role) => {
+    if (accessToken) {
+      localStorage.setItem('access_token', accessToken);
+      localStorage.setItem('accessToken', accessToken);
+      const a = decodeJwt(accessToken);
+      if (a?.exp) localStorage.setItem('access_exp', String(a.exp));
+    }
+    if (refreshToken) {
+      localStorage.setItem('refresh_token', refreshToken);
+      localStorage.setItem('refreshToken', refreshToken);
+      const r = decodeJwt(refreshToken);
+      if (r?.exp) localStorage.setItem('refresh_exp', String(r.exp));
+    }
+    if (role) localStorage.setItem('userRole', role);
+  };
 
   const onRequest = async (e) => {
     e?.preventDefault?.();
@@ -66,15 +96,21 @@ export default function LoginPhone() {
     }
     setLoading(true);
     try {
-      const { profile_complete } = await verifyPhoneOtp(normalized, code.trim());
+      // ⬇️ IMPORTANTE: asegúrate de que tu backend devuelva también refresh_token y role
+      // Respuesta esperada: { access_token, refresh_token, role, profile_complete, ... }
+      const data = await verifyPhoneOtp(normalized, code.trim());
 
+      // Persistimos sesión
+      persistAuth(data.access_token, data.refresh_token, data.role);
       // Guardamos el teléfono tras verificar correctamente
       setLastPhone(normalized);
 
       toast.success('Sesión iniciada');
 
-      if (!profile_complete) {
-        // Ojo: ruta dentro del dashboard para el perfil de cliente
+      // Redirección:
+      // - Si el perfil no está completo, te mando al perfil cliente
+      // - Si está completo, voy a "next" (o home) respetando el query param
+      if (!data?.profile_complete) {
         navigate('/dashboard/client/profile', { replace: true });
       } else {
         navigate(next, { replace: true });


### PR DESCRIPTION
Contexto

Los tokens de acceso expiraban cada hora y los usuarios veían 401 al pasar ese tiempo. Implementamos renovación silenciosa mediante refresh_token para poder solicitar un nuevo access_token sin pedir credenciales otra vez.

Cambios principales

Login (POST /api/auth/login):

Ahora devuelve también refresh_token además de access_token, user_id y role.

Refresh (POST /api/auth/refresh):

Nuevo endpoint protegido con @jwt_required(refresh=True) que emite un nuevo access_token usando el refresh_token.

Config (backend/config.py):

Expiración configurable vía entorno:

JWT_ACCESS_TOKEN_EXPIRES (por defecto 3600s)

JWT_REFRESH_TOKEN_EXPIRES (por defecto 2592000s = 30 días)

Internamente usamos timedelta para compatibilidad con flask_jwt_extended.

Endpoints

POST /api/auth/login

Request: { "email": "...", "password": "..." }

Response: { "access_token": "...", "refresh_token": "...", "user_id": 1, "role": "provider|client|admin" }

POST /api/auth/refresh

Headers: Authorization: Bearer <refresh_token>

Response: { "access_token": "..." }

Cómo probar (manual)
# 1) Login
curl -s -X POST http://localhost:5001/api/auth/login \
  -H 'Content-Type: application/json' \
  -d '{"email":"miuser@demo.com","password":"MiClaveSegura123!"}'

# => Guarda access_token y refresh_token

# 2) Refrescar (con el refresh_token)
curl -s -X POST http://localhost:5001/api/auth/refresh \
  -H "Authorization: Bearer <REFRESH_TOKEN>"

Variables de entorno nuevas/actualizadas

JWT_ACCESS_TOKEN_EXPIRES (segundos, default 3600)

JWT_REFRESH_TOKEN_EXPIRES (segundos, default 2592000)

Ejemplo .env:
JWT_ACCESS_TOKEN_EXPIRES=3600
JWT_REFRESH_TOKEN_EXPIRES=2592000

Compatibilidad

El access_token sigue funcionando como antes.

El frontend actual puede seguir usando access_token. Añadiremos la renovación silenciosa en otra rama (interceptor / fetch wrapper).

Riesgos

Asegurar que el cliente no envíe el refresh_token por accidente a endpoints normales (solo al de refresh).

Revisar logs de CORS si cambiamos dominios.

Checklist

 POST /api/auth/login devuelve también refresh_token.

 POST /api/auth/refresh crea nuevo access_token usando el refresh.

 Config de expiraciones en backend/config.py.

 CORS ok en dev (http://localhost:5173).

 Probado con curl.
 
 3) Siguiente paso (mañana)

En una rama nueva feature/silent-refresh-frontend:

Guardar refresh_token en localStorage (en dev) junto a access_token.

Interceptor/fetch-wrapper:

Si access_token expira (401/Token has expired), pedir nuevo access_token a /api/auth/refresh con el refresh_token, persistirlo y reintentar la petición original.

Opcional: usar httpOnly cookie para refresh_token si quieres subir el listón de seguridad.