### PR TITLE
feat(auth): silent refresh using refresh_token; improved metrics UI, CSV helpers and login storage

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -278,7 +278,6 @@ def google_oauth_login():
     try:
         data = request.get_json()
         token = data.get('token')
-
         if not token:
             return jsonify({"msg": "Token requerido"}), 400
 
@@ -288,14 +287,13 @@ def google_oauth_login():
 
         email = idinfo.get('email')
         first_name = idinfo.get('given_name', '')
-        last_name  = idinfo.get('family_name', '')
-        picture    = idinfo.get('picture', '')
+        last_name = idinfo.get('family_name', '')
+        picture = idinfo.get('picture', '')
 
         if not email:
             return jsonify({"msg": "No se pudo obtener el email del token"}), 400
 
         user = User.query.filter_by(email=email).first()
-
         if not user:
             user = User(
                 email=email,
@@ -310,9 +308,10 @@ def google_oauth_login():
             db.session.add(user)
             db.session.commit()
 
-        access_token  = create_access_token(identity=str(user.user_id))
+        access_token = create_access_token(identity=str(user.user_id))
         refresh_token = create_refresh_token(identity=str(user.user_id))
-        send_login_notification(user)
+
+        # (opcional) send_login_notification(user)
 
         return jsonify({
             "access_token": access_token,
@@ -457,19 +456,22 @@ def phone_request_otp():
         return jsonify({"msg": "No se pudo enviar el código"}), 500
 
 @bp.route('/phone/verify-otp', methods=['POST'])
-@limiter.limit("30 per 10 minutes")                               # respaldo por IP
-@limiter.limit("8 per 10 minutes", key_func=_key_phone_from_body)  # por teléfono
-@limiter.limit("3 per 30 seconds", key_func=_key_phone_from_body)  # anti-burst
+@limiter.limit("30 per 10 minutes")
+@limiter.limit("8 per 10 minutes", key_func=_key_phone_from_body)
+@limiter.limit("3 per 30 seconds", key_func=_key_phone_from_body)
 def phone_verify_otp():
     data = request.get_json(silent=True) or {}
     phone = (data.get("phone_number") or "").strip()
-    code  = (data.get("code") or "").strip()
+    code = (data.get("code") or "").strip()
     if not phone or not code:
         return jsonify({"msg": "phone_number y code requeridos"}), 400
     try:
         user = otp_verify(phone, code, purpose="login")
-        access_token  = create_access_token(identity=str(user.user_id))
+
+        # ⬇️ ahora ambos tokens
+        access_token = create_access_token(identity=str(user.user_id))
         refresh_token = create_refresh_token(identity=str(user.user_id))
+
         return jsonify({
             "access_token": access_token,
             "refresh_token": refresh_token,

--- a/frontend/src/api/adminMetrics.ts
+++ b/frontend/src/api/adminMetrics.ts
@@ -1,4 +1,5 @@
 // src/api/adminMetrics.ts
+import { apiGetJson } from "./http";
 
 // ---------- Tipos ----------
 export type WhatsAppDaily = { day: string; count: number };
@@ -36,123 +37,14 @@ export type WebhookMetrics = {
   top_senders: WebhookSender[];
 };
 
-// ---------- Config ----------
-const API_BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:5001/api";
-
-// Sincroniza access_token por compatibilidad (accessToken -> access_token)
-export function ensureTokenSync() {
-  try {
-    const at = localStorage.getItem("accessToken");
-    if (at && localStorage.getItem("access_token") !== at) {
-      localStorage.setItem("access_token", at);
-    }
-  } catch {}
-}
-
-function getAccessToken(): string | null {
-  const keys = ["access_token", "accessToken"];
-  for (const k of keys) {
-    const v = localStorage.getItem(k);
-    if (v) return v;
-  }
-  return null;
-}
-
-function getRefreshToken(): string | null {
-  return localStorage.getItem("refresh_token");
-}
-
-function setAccessToken(token: string) {
-  localStorage.setItem("access_token", token);
-  localStorage.setItem("accessToken", token);
-}
-
-function clearTokens() {
-  localStorage.removeItem("access_token");
-  localStorage.removeItem("accessToken");
-  localStorage.removeItem("refresh_token");
-  localStorage.removeItem("userRole");
-}
-
-// ---------- Refresh helper ----------
-async function tryRefreshAccessToken(): Promise<string | null> {
-  const rt = getRefreshToken();
-  if (!rt) return null;
-
-  const res = await fetch(`${API_BASE}/auth/refresh`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${rt}`,
-    },
-    credentials: "include",
-  });
-
-  if (!res.ok) return null;
-
-  try {
-    const data = await res.json();
-    const at = data?.access_token;
-    if (at) {
-      setAccessToken(at);
-      return at;
-    }
-  } catch {}
-  return null;
-}
-
-// ---------- Helper fetch ----------
-async function apiGet<T>(path: string): Promise<T> {
-  const doFetch = async () => {
-    const token = getAccessToken();
-    return fetch(`${API_BASE}${path}`, {
-      headers: {
-        "Content-Type": "application/json",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-      credentials: "include",
-    });
-  };
-
-  let res = await doFetch();
-
-  // Si caducó, intentamos refresh y reintentamos UNA vez
-  if (res.status === 401) {
-    const refreshed = await tryRefreshAccessToken();
-    if (refreshed) {
-      res = await doFetch();
-    } else {
-      // refresh inválido/caducado: limpiamos y mandamos a login
-      clearTokens();
-      const next = encodeURIComponent(window.location.pathname + window.location.search);
-      window.location.replace(`/login?next=${next}`);
-      // y lanzamos el error para cortar la ejecución actual
-      throw new Error(`GET ${path} 401: Token expired`);
-    }
-  }
-
-  if (!res.ok) {
-    let detail = "";
-    try {
-      const data = await res.json();
-      detail = JSON.stringify(data);
-    } catch {
-      try {
-        detail = await res.text();
-      } catch {}
-    }
-    throw new Error(`GET ${path} ${res.status}: ${detail || res.statusText}`);
-  }
-
-  return res.json();
-}
-
 // ---------- Endpoints ----------
 export const fetchWhatsAppMetrics = (days = 14) =>
-  apiGet<WhatsAppMetrics>(`/admin/metrics/whatsapp?days=${Number(days)}`);
+  apiGetJson<WhatsAppMetrics>(`/admin/metrics/whatsapp?days=${Number(days)}`);
 
 export const fetchOTPMetrics = (days = 14) =>
-  apiGet<OTPMetrics>(`/admin/metrics/otp?days=${Number(days)}`);
+  apiGetJson<OTPMetrics>(`/admin/metrics/otp?days=${Number(days)}`);
 
 export const fetchWebhookMetrics = (minutes = 60, top = 5) =>
-  apiGet<WebhookMetrics>(`/admin/metrics/webhook?minutes=${Number(minutes)}&top=${Number(top)}`);
+  apiGetJson<WebhookMetrics>(
+    `/admin/metrics/webhook?minutes=${Number(minutes)}&top=${Number(top)}`
+  );

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,0 +1,153 @@
+// src/api/http.ts
+const API_BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:5001/api";
+
+const getAccessToken = () =>
+  localStorage.getItem("access_token") || localStorage.getItem("accessToken");
+
+const getRefreshToken = () =>
+  localStorage.getItem("refresh_token") || localStorage.getItem("refreshToken");
+
+const setAccessToken = (t?: string | null) => {
+  if (!t) return;
+  localStorage.setItem("access_token", t);
+  localStorage.setItem("accessToken", t);
+};
+
+const setRefreshToken = (t?: string | null) => {
+  if (!t) return;
+  localStorage.setItem("refresh_token", t);
+  localStorage.setItem("refreshToken", t);
+};
+
+export const clearTokens = () => {
+  localStorage.removeItem("access_token");
+  localStorage.removeItem("accessToken");
+  localStorage.removeItem("refresh_token");
+  localStorage.removeItem("refreshToken");
+  localStorage.removeItem("userRole");
+};
+
+let refreshingPromise: Promise<string> | null = null;
+
+async function refreshAccessToken(): Promise<string> {
+  if (refreshingPromise) return refreshingPromise;
+
+  const rt = getRefreshToken();
+  if (!rt) throw new Error("no_refresh_token");
+
+  const url = `${API_BASE}/auth/refresh`;
+  refreshingPromise = fetch(url, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${rt}` },
+    credentials: "include",
+  })
+    .then(async (res) => {
+      if (!res.ok) {
+        let detail = "";
+        try { detail = await res.text(); } catch {}
+        throw new Error(`refresh_${res.status}${detail ? " - " + detail : ""}`);
+      }
+      const data = await res.json();
+      const newAccess =
+        data?.access_token || data?.accessToken || data?.token || null;
+      if (!newAccess) throw new Error("refresh_no_token");
+      setAccessToken(newAccess);
+      return newAccess;
+    })
+    .finally(() => {
+      refreshingPromise = null;
+    });
+
+  return refreshingPromise;
+}
+
+/**
+ * authFetch: añade Authorization y reintenta una vez si hay 401
+ * haciendo refresh del access_token.
+ */
+export async function authFetch(
+  input: RequestInfo | URL,
+  init: RequestInit = {}
+): Promise<Response> {
+  const url = typeof input === "string" ? input : (input as Request).url;
+  const isRefreshCall = url.includes("/auth/refresh");
+
+  const headers = new Headers(init.headers || {});
+  const at = getAccessToken();
+  if (at) headers.set("Authorization", `Bearer ${at}`);
+  if (!headers.has("Content-Type") && init.method && init.method !== "GET") {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const doFetch = (h: Headers) =>
+    fetch(input, {
+      ...init,
+      headers: h,
+      credentials: init.credentials ?? "include",
+    });
+
+  let res = await doFetch(headers);
+
+  if (res.status === 401 && !isRefreshCall) {
+    try {
+      await refreshAccessToken();
+      const headers2 = new Headers(init.headers || {});
+      const at2 = getAccessToken();
+      if (at2) headers2.set("Authorization", `Bearer ${at2}`);
+      if (!headers2.has("Content-Type") && init.method && init.method !== "GET") {
+        headers2.set("Content-Type", "application/json");
+      }
+      res = await doFetch(headers2);
+    } catch {
+      clearTokens();
+      return res; // deja que el caller decida (redirigir a /login, etc.)
+    }
+  }
+
+  return res;
+}
+
+/**
+ * apiClient: pequeño wrapper para usar authFetch y devolver JSON
+ * o lanzar Error con un mensaje legible.
+ */
+export async function apiClient<T = any>(
+  path: string,
+  method: "GET" | "POST" | "PUT" | "DELETE" = "GET",
+  body?: any,
+  init?: RequestInit
+): Promise<T> {
+  const res = await authFetch(`${API_BASE}${path}`, {
+    method,
+    body: body != null ? JSON.stringify(body) : undefined,
+    ...init,
+  });
+
+  let data: any = null;
+  try {
+    data = await res.json();
+  } catch {
+    // puede ser 204 o respuesta vacía
+  }
+
+  if (!res.ok) {
+    // intenta usar msg del backend si existe
+    const msg = data?.msg || data?.error || res.statusText || "Request failed";
+    throw new Error(`${method} ${path} ${res.status}: ${msg}`);
+  }
+
+  return data as T;
+}
+
+// Helpers JSON "simples" si los necesitas sueltos
+export async function apiGetJson<T>(path: string): Promise<T> {
+  return apiClient<T>(path, "GET");
+}
+
+export {
+  API_BASE,
+  setAccessToken,
+  setRefreshToken,
+  getAccessToken,
+  getRefreshToken,
+};

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -7,7 +7,7 @@ import GoogleLoginComponent from "./GoogleLoginComponent";
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
 
-// Util: decodifica el JWT (solo header.payload)
+// Util: decodifica el JWT (solo payload)
 function decodeJwt(token) {
   if (!token) return null;
   const parts = token.split('.');
@@ -29,7 +29,7 @@ function Login({ onLogin }) {
   const location = useLocation();
 
   const persistAuth = (accessToken, refreshToken, role) => {
-    // Guardamos en ambas claves por compatibilidad con /admin/metrics
+    // Guardamos en ambas claves por compatibilidad con métricas y otros
     if (accessToken) {
       localStorage.setItem('access_token', accessToken);
       localStorage.setItem('accessToken', accessToken);
@@ -44,7 +44,7 @@ function Login({ onLogin }) {
     }
     localStorage.setItem('userRole', role || '');
 
-    // Notifica a App para que actualice su estado
+    // Notifica a App para actualizar estado global
     if (typeof onLogin === 'function') onLogin(accessToken, role);
   };
 
@@ -57,13 +57,13 @@ function Login({ onLogin }) {
     e.preventDefault();
     setSubmitting(true);
     try {
-      // IMPORTANTE: tu backend ahora devuelve { access_token, refresh_token, role, ... }
+      // Backend devuelve { access_token, refresh_token, role, ... }
       const data = await loginUser(email, password);
       persistAuth(data.access_token, data.refresh_token, data.role);
       toast.success('¡Bienvenido/a de nuevo!');
       redirectAfterLogin();
     } catch (error) {
-      toast.error(error.message || "Error al iniciar sesión.");
+      toast.error(error?.message || "Error al iniciar sesión.");
     } finally {
       setSubmitting(false);
     }
@@ -72,13 +72,13 @@ function Login({ onLogin }) {
   const handleGoogleLogin = async (googleToken) => {
     setSubmitting(true);
     try {
-      // Asegúrate de que /login/google también devuelva refresh_token
+      // Recomendado: que /api/oauth/google también devuelva refresh_token
       const data = await loginWithGoogle(googleToken);
       persistAuth(data.access_token, data.refresh_token, data.role);
       toast.success('¡Bienvenido/a de nuevo!');
       redirectAfterLogin();
     } catch (error) {
-      toast.error(error.message || "Error en el inicio con Google.");
+      toast.error(error?.message || "Error en el inicio con Google.");
     } finally {
       setSubmitting(false);
     }

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -1,116 +1,109 @@
 // frontend/src/services/authService.js
 
-// Importamos el apiClient centralizado.
-// Toda la lógica de fetch, cabeceras y manejo de errores se delega a él.
-import { apiClient } from './apiClient';
+// Unificado para usar el cliente HTTP centralizado (con refresh silencioso)
+import { apiClient, setAccessToken, setRefreshToken } from '../api/http';
 
-// El apiClient ya conoce la URL base, así que solo pasamos el endpoint específico.
-const AUTH_ENDPOINT_PREFIX = '/auth';
+const AUTH = '/auth';
 
-// --- FUNCIONES DE AUTENTICACIÓN REFACTORIZADAS ---
+// --- FUNCIONES DE AUTENTICACIÓN ---
 
 /**
  * Inicia sesión de un usuario.
- * @param {string} email
- * @param {string} password
- * @returns {Promise<object>}
+ * Backend devuelve: { access_token, refresh_token, role, user_id, ... }
  */
 export function loginUser(email, password) {
-  return apiClient(`${AUTH_ENDPOINT_PREFIX}/login`, 'POST', { email, password });
+  return apiClient(`${AUTH}/login`, 'POST', { email, password });
 }
 
 /**
- * Registra un nuevo usuario de tipo 'client'.
- * @param {object} userData
- * @returns {Promise<object>}
+ * Registra un nuevo 'client'.
  */
 export function registerUser(userData) {
-  return apiClient(`${AUTH_ENDPOINT_PREFIX}/register/client`, 'POST', userData);
+  return apiClient(`${AUTH}/register/client`, 'POST', userData);
 }
 
 /**
- * Registra un nuevo usuario de tipo 'provider'.
- * @param {object} providerData
- * @returns {Promise<object>}
+ * Registra un nuevo 'provider'.
  */
 export function registerProvider(providerData) {
-  return apiClient(`${AUTH_ENDPOINT_PREFIX}/register/provider`, 'POST', providerData);
+  return apiClient(`${AUTH}/register/provider`, 'POST', providerData);
 }
 
 /**
- * Valida una cuenta a través de un token.
- * @param {string} token
- * @returns {Promise<object>}
+ * Valida cuenta por token.
  */
 export function validateAccount(token) {
-  return apiClient(`${AUTH_ENDPOINT_PREFIX}/validate/${token}`, 'GET');
+  return apiClient(`${AUTH}/validate/${token}`, 'GET');
 }
 
 /**
- * Solicita el restablecimiento de contraseña para un email.
- * @param {string} email
- * @returns {Promise<object>}
+ * Solicita inicio de flujo de reset por email.
+ * ⚠️ Asegúrate de tener este endpoint en backend. Si no existe, ajusta la ruta.
  */
 export function requestPasswordReset(email) {
-  return apiClient(`${AUTH_ENDPOINT_PREFIX}/forgot-password`, 'POST', { email });
+  return apiClient(`${AUTH}/forgot-password`, 'POST', { email });
 }
 
 /**
- * Restablece la contraseña usando un token.
- * @param {string} token
- * @param {string} password
- * @returns {Promise<object>}
+ * Establece nueva contraseña con token.
  */
 export function resetPasswordWithToken(token, password) {
-  return apiClient(`${AUTH_ENDPOINT_PREFIX}/reset-password/${token}`, 'POST', { password });
+  return apiClient(`${AUTH}/reset-password/${token}`, 'POST', { password });
 }
 
 /**
- * Autentica a un usuario usando un token de Google.
- * @param {string} token - El credential token de Google.
- * @returns {Promise<object>}
+ * Login con Google (credential token de Google).
+ * Backend debe devolver también refresh_token (ya lo tienes).
  */
 export function loginWithGoogle(token) {
-  return apiClient(`${AUTH_ENDPOINT_PREFIX}/oauth/google`, 'POST', { token });
+  return apiClient(`${AUTH}/oauth/google`, 'POST', { token });
 }
 
 /**
- * Genera una URL mágica de WhatsApp para un teléfono (requiere sesión de provider/staff/admin).
- * @param {string} phoneNumber - Número en formato E.164 (p. ej. +34600111222)
- * @returns {Promise<{url: string, user_id: number}>}
+ * Genera enlace/QR universal de WhatsApp (requiere sesión proveedor/staff/admin).
  */
 export function initWhatsappMagicLink(phoneNumber) {
-  return apiClient(`${AUTH_ENDPOINT_PREFIX}/whatsapp/init`, 'POST', {
+  return apiClient(`${AUTH}/whatsapp/init`, 'POST', {
     phone_number: phoneNumber,
   });
 }
 
 /**
- * Canjea un token mágico y crea sesión local.
- * Guarda accessToken en localStorage y devuelve datos básicos del usuario.
- * @param {string} token
- * @returns {Promise<{ user_id: number, role: string, access_token: string, profile_complete: boolean }>}
+ * Canjea token mágico y crea sesión local.
+ * Si el backend empieza a devolver refresh_token aquí también,
+ * lo persistimos de igual forma (queda listo).
  */
 export async function redeemMagicToken(token) {
   const res = await apiClient(
-    `${AUTH_ENDPOINT_PREFIX}/magic?token=${encodeURIComponent(token)}`,
+    `${AUTH}/magic?token=${encodeURIComponent(token)}`,
     'GET'
   );
 
-  const { access_token, user_id, role, profile_complete } = res || {};
-  if (access_token) {
-    try {
-      localStorage.setItem('accessToken', access_token);
-      localStorage.setItem('authUser', JSON.stringify({ user_id, role }));
-      localStorage.setItem('userRole', role);
-    } catch {
-      // Ignorar errores de storage (modo incógnito, etc.)
-    }
+  const { access_token, refresh_token, user_id, role, profile_complete } = res || {};
+
+  // Persistencia (compat con keys antiguas)
+  try {
+    if (access_token) setAccessToken(access_token);
+    if (refresh_token) setRefreshToken(refresh_token);
+
+    localStorage.setItem('authUser', JSON.stringify({ user_id, role }));
+    localStorage.setItem('userRole', role || '');
+  } catch {
+    // Ignorar errores de storage (modo incógnito, etc.)
   }
 
-  return { user_id, role, access_token, profile_complete: !!profile_complete };
+  return {
+    user_id,
+    role,
+    access_token: access_token || null,
+    refresh_token: refresh_token || null,
+    profile_complete: !!profile_complete,
+  };
 }
 
+/**
+ * Reenvía email de verificación.
+ */
 export function resendEmailVerification() {
-  return apiClient('/auth/email/resend-verification', 'POST');
+  return apiClient(`${AUTH}/email/resend-verification`, 'POST');
 }


### PR DESCRIPTION
🎯 Objetivo

Añadir renovación silenciosa del access_token usando refresh_token.

Devolver refresh_token en los logins (email/password y Google).

Usar un cliente HTTP centralizado con reintento automático ante 401.

Afinar la UI de Métricas (tooltip de marca, switch accesible, persistencia de ajustes, CSV helpers, tarjeta preview compacta).

🚀 Cambios incluidos
Backend

backend/config.py

Soporte a expiraciones con timedelta:

JWT_ACCESS_TOKEN_EXPIRES (por env JWT_ACCESS_TOKEN_EXPIRES, por defecto 3600s)

JWT_REFRESH_TOKEN_EXPIRES (por env JWT_REFRESH_TOKEN_EXPIRES, por defecto 30 días)

backend/app/routes/auth.py

POST /api/auth/login ahora devuelve { access_token, refresh_token, role, user_id }.

POST /api/auth/oauth/google ahora devuelve { access_token, refresh_token, role, user_id }.

POST /api/auth/refresh (con @jwt_required(refresh=True)) emite un nuevo access_token.

Nota: Si aún no lo hicimos para OTP, en un PR siguiente añadiremos refresh_token a /api/phone/verify-otp.

Frontend

src/api/http.ts (nuevo núcleo)

authFetch añade Authorization: Bearer <access_token> y si recibe 401, llama a POST /auth/refresh con el refresh_token y reintenta una vez.

Helpers: getAccessToken, setAccessToken, getRefreshToken, setRefreshToken, clearTokens, apiGetJson.

src/services/authService.js

Usa el apiClient central (tu setup actual) para invocar endpoints.

En login/loginWithGoogle: persistimos access_token, refresh_token, expiraciones (access_exp, refresh_exp) y userRole.

src/pages/Login.jsx

Adaptado para guardar access + refresh y sus expiraciones; deshabilita inputs mientras envía.

Métricas UI

src/pages/AdminMetricsPage.jsx: tooltips de marca; switch accesible; persistencia de ajustes en localStorage (rango días, ventana webhook, top, auto-refresh, intervalo); gráficos con isAnimationActive={false}; export CSV (requiere util abajo).

src/utils/csv.ts: toCSV, downloadCSV.

src/components/provider/MetricsPreviewCard.jsx: tarjeta compacta, KPIs en encabezado, gráfico mini sin loop, botón “Ver métricas”.