### PR TITLE
Feature/auth refresh unification

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,8 +34,12 @@ import Magic from './pages/Magic';
 import LoginPhone from './pages/LoginPhone';
 import ProviderWhatsAppQR from './pages/ProviderWhatsAppQR';
 import AdminMetricsPage from "./pages/AdminMetricsPage";
+import useProactiveRefresh from './hooks/useProactiveRefresh';
 
 function App() {
+  // 🔁 Renovación silenciosa del access token antes de caducar
+  useProactiveRefresh({ leadSeconds: 120, minInterval: 60 });
+
   const [token, setToken] = useState(localStorage.getItem('accessToken') || localStorage.getItem('access_token'));
   const [role, setRole] = useState(localStorage.getItem('userRole'));
 

--- a/frontend/src/components/auth/ProtectedRoute.jsx
+++ b/frontend/src/components/auth/ProtectedRoute.jsx
@@ -1,128 +1,15 @@
-// frontend/src/components/auth/ProtectedRoute.jsx
-import { useEffect, useMemo, useState } from 'react';
-import { Navigate, Outlet, useLocation } from 'react-router-dom';
+// src/components/auth/ProtectedRoute.jsx
+import { Outlet, Navigate, useLocation } from 'react-router-dom';
 import { getAccessToken, getRefreshToken } from '../../api/http';
 
-// Util simple para decodificar JWT (payload)
-function decodeJwt(token) {
-  if (!token) return null;
-  const parts = token.split('.');
-  if (parts.length < 2) return null;
-  try {
-    const json = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
-    return json || null;
-  } catch {
-    return null;
-  }
-}
-
-// Pequeño helper para saber si está expirado (o a punto) con margen
-function isExpired(token, skewSeconds = 10) {
-  const payload = decodeJwt(token);
-  if (!payload?.exp) return true; // si no hay exp, trátalo como expirado
-  const now = Math.floor(Date.now() / 1000);
-  return payload.exp <= (now + skewSeconds);
-}
-
-// Redirige a /login preservando next
-function goLoginWithNext(pathname, search) {
-  try {
-    const here = `${pathname}${search || ''}`;
-    const next = encodeURIComponent(here);
-    if (!pathname.startsWith('/login')) {
-      window.location.assign(`/login?next=${next}`);
-    }
-  } catch {
-    // no-op
-  }
-}
-
-export default function ProtectedRoute({ token: _tokenProp }) {
+export default function ProtectedRoute() {
   const location = useLocation();
-  const [checking, setChecking] = useState(true);
-  const [allowed, setAllowed] = useState(false);
+  const at = getAccessToken();
+  const rt = getRefreshToken();
 
-  // Leemos tokens siempre desde localStorage (fuente de verdad para http.js)
-  const access = useMemo(() => getAccessToken(), []);
-  const refresh = useMemo(() => getRefreshToken(), []);
+  // Si hay access o refresh, deja pasar: los fetch protegidos harán refresh si hace falta.
+  if (at || rt) return <Outlet />;
 
-  useEffect(() => {
-    let mounted = true;
-
-    async function check() {
-      // 1) No hay access ni refresh -> a login
-      if (!access && !refresh) {
-        if (!mounted) return;
-        setAllowed(false);
-        setChecking(false);
-        goLoginWithNext(location.pathname, location.search);
-        return;
-      }
-
-      // 2) Hay access y NO está expirado -> pasar
-      if (access && !isExpired(access)) {
-        if (!mounted) return;
-        setAllowed(true);
-        setChecking(false);
-        return;
-      }
-
-      // 3) Intentar refresh: hacemos una llamada inofensiva al backend a través de http.js
-      //    La lógica centralizada se encargará del refresh y/o redirección si falla.
-      try {
-        // Cualquier GET protegido sirve; usamos /auth/email/resend-verification que exige JWT.
-        const res = await fetch(
-          `${import.meta.env.VITE_API_BASE ?? 'http://localhost:5001/api'}/auth/email/resend-verification`,
-          {
-            method: 'POST',
-            // No ponemos Authorization aquí; http.js es quien añade y refresca.
-            // Peeero aquí NO estamos usando authFetch para no crear dependencia circular.
-            // Esta llamada es sólo para forzar refresh desde http.js cuando se consuma a través de apiClient/authFetch.
-            // Si prefieres evitar efectos, cambia esta comprobación por una llamada real desde una ruta que use apiClient.
-            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getAccessToken() || ''}` },
-            credentials: 'include',
-          }
-        );
-
-        // Si el refresh se hizo bien, http.js habrá regenerado el access y esta request
-        // normalmente devolverá 200/400 (dependiendo del estado de verificación). Lo importante es que no sea 401.
-        if (res.status === 401) {
-          // http.js ya habrá intentado refrescar. Si seguimos en 401, toca login.
-          if (!mounted) return;
-          setAllowed(false);
-          setChecking(false);
-          goLoginWithNext(location.pathname, location.search);
-        } else {
-          if (!mounted) return;
-          setAllowed(true);
-          setChecking(false);
-        }
-      } catch {
-        // Cualquier fallo de red -> mejor llevar a login
-        if (!mounted) return;
-        setAllowed(false);
-        setChecking(false);
-        goLoginWithNext(location.pathname, location.search);
-      }
-    }
-
-    check();
-    return () => { mounted = false; };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location.pathname, location.search]);
-
-  if (checking) {
-    return (
-      <div className="min-h-[40vh] flex items-center justify-center">
-        <div className="animate-pulse text-sm text-slate-500">Comprobando sesión…</div>
-      </div>
-    );
-  }
-
-  if (!allowed) {
-    // La redirección ya la hemos disparado; devolvemos un fallback por si React renderiza algo en medio
-    return <Navigate to="/login" replace state={{ from: location }} />;
-  }
-
-  return <Outlet />;
+  // Sin ningún token -> a login con “next”
+  return <Navigate to="/login" state={{ from: location }} replace />;
 }

--- a/frontend/src/components/auth/TokenBadge.jsx
+++ b/frontend/src/components/auth/TokenBadge.jsx
@@ -1,0 +1,90 @@
+// src/components/auth/TokenBadge.jsx
+import { useEffect, useState } from 'react';
+
+// Util: decodifica payload del JWT
+function decodeJwt(token) {
+  if (!token) return null;
+  const parts = token.split('.');
+  if (parts.length < 2) return null;
+  try {
+    return JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/'))) || null;
+  } catch {
+    return null;
+  }
+}
+
+export default function TokenBadge({ skew = 0 }) {
+  const isDev = import.meta.env.MODE === 'development';
+  const qsOn = typeof window !== 'undefined' && /\bdebugToken=1\b/.test(window.location.search);
+
+  const [visible, setVisible] = useState(() => {
+    if (!isDev) return false;
+    if (qsOn) {
+      try { localStorage.setItem('DEBUG_TOKEN_BADGE', '1'); } catch {}
+      return true;
+    }
+    try {
+      return localStorage.getItem('DEBUG_TOKEN_BADGE') === '1';
+    } catch {
+      return false;
+    }
+  });
+
+  const [leftAccess, setLeftAccess] = useState(null);
+  const [leftRefresh, setLeftRefresh] = useState(null);
+
+  // Tecla rápida: Ctrl/Cmd + Alt + T
+  useEffect(() => {
+    if (!isDev) return;
+    const onKey = (e) => {
+      const cmdOrCtrl = e.metaKey || e.ctrlKey;
+      if (cmdOrCtrl && e.altKey && (e.key === 't' || e.key === 'T')) {
+        const next = !visible;
+        setVisible(next);
+        try { localStorage.setItem('DEBUG_TOKEN_BADGE', next ? '1' : '0'); } catch {}
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [visible, isDev]);
+
+  // Contadores (solo si visible)
+  useEffect(() => {
+    if (!isDev || !visible) return;
+    const tick = () => {
+      const at = localStorage.getItem('access_token') || localStorage.getItem('accessToken');
+      const rt = localStorage.getItem('refresh_token') || localStorage.getItem('refreshToken');
+      const now = Math.floor(Date.now() / 1000);
+      const ax = decodeJwt(at)?.exp ?? 0;
+      const rx = decodeJwt(rt)?.exp ?? 0;
+      setLeftAccess(ax ? Math.max(0, ax - now - skew) : null);
+      setLeftRefresh(rx ? Math.max(0, rx - now - skew) : null);
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [isDev, visible, skew]);
+
+  if (!isDev || !visible) return null;
+
+  const fmt = (n) => {
+    const m = Math.floor(n / 60);
+    const s = n % 60;
+    return `${m}:${String(s).padStart(2, '0')}`;
+  };
+
+  const critical = (leftAccess ?? 0) <= 120;
+
+  return (
+    <span
+      className={
+        'ml-2 inline-flex items-center gap-2 rounded px-2 py-0.5 text-xs ' +
+        (critical ? 'bg-rose-100 text-rose-700' : 'bg-emerald-100 text-emerald-700')
+      }
+      title="Token timers (Ctrl/Cmd + Alt + T para mostrar/ocultar)"
+    >
+      {leftAccess != null && <>Access&nbsp;{fmt(leftAccess)}</>}
+      {leftRefresh != null && <>&nbsp;·&nbsp;Refresh&nbsp;{fmt(leftRefresh)}</>}
+    </span>
+  );
+}

--- a/frontend/src/hooks/useProactiveRefresh.js
+++ b/frontend/src/hooks/useProactiveRefresh.js
@@ -1,0 +1,119 @@
+// src/hooks/useProactiveRefresh.js
+import { useEffect, useRef } from 'react';
+import {
+  getAccessToken,
+  getRefreshToken,
+  refreshAccessToken, // <- exportado por ../api/http
+} from '../api/http';
+
+// Decodifica payload del JWT
+function decodeJwt(token) {
+  if (!token) return null;
+  const parts = token.split('.');
+  if (parts.length < 2) return null;
+  try {
+    return JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
+  } catch {
+    return null;
+  }
+}
+function getExp(token) {
+  const p = decodeJwt(token);
+  return p?.exp || null;
+}
+
+/**
+ * Refresca silenciosamente el access token antes de que caduque.
+ * - leadSeconds: margen en segundos para refrescar antes de expirar (p.ej. 90s)
+ * - minInterval: intervalo de seguridad para re-chequear (p.ej. 60s)
+ */
+export default function useProactiveRefresh({ leadSeconds = 90, minInterval = 60 } = {}) {
+  const timeoutRef = useRef(null);
+  const intervalRef = useRef(null);
+
+  const clearTimers = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  };
+
+  const schedule = () => {
+    clearTimers();
+
+    const rt = getRefreshToken();
+    if (!rt) return; // sin refresh no programamos nada
+
+    const at = getAccessToken();
+    const exp = getExp(at);
+    if (!exp) return; // sin exp no programamos
+
+    const now = Math.floor(Date.now() / 1000);
+    const fireIn = Math.max(0, (exp - leadSeconds) - now);
+
+    const triggerRefresh = async () => {
+      try {
+        await refreshAccessToken(); // si falla, http.js ya manejará el 401 en la próxima request
+      } catch {
+        // silencio; próximo fetch decidirá (apiClient redirigirá si corresponde)
+      } finally {
+        // reprograma con el nuevo access token
+        schedule();
+      }
+    };
+
+    if (fireIn <= 0) {
+      // ya estamos dentro de la ventana -> refresca ya
+      triggerRefresh();
+    } else {
+      timeoutRef.current = setTimeout(triggerRefresh, fireIn * 1000);
+    }
+
+    // Intervalo de seguridad por si el token cambia fuera de nuestro control
+    const safeInterval = Math.max(15, minInterval);
+    intervalRef.current = setInterval(() => {
+      const at2 = getAccessToken();
+      const exp2 = getExp(at2);
+      if (!exp2) return;
+      const now2 = Math.floor(Date.now() / 1000);
+      if (exp2 - now2 <= leadSeconds) {
+        triggerRefresh();
+      }
+    }, safeInterval * 1000);
+  };
+
+  useEffect(() => {
+    schedule();
+
+    const onFocus = () => {
+      // al volver a la pestaña, intenta refrescar si estamos cerca
+      const at = getAccessToken();
+      const exp = getExp(at);
+      const now = Math.floor(Date.now() / 1000);
+      if (exp && exp - now <= leadSeconds) {
+        refreshAccessToken().finally(schedule);
+      }
+    };
+
+    const onStorage = (e) => {
+      // si cambian tokens en otra pestaña, reprograma
+      if (['access_token', 'accessToken', 'refresh_token', 'refreshToken'].includes(e.key)) {
+        schedule();
+      }
+    };
+
+    window.addEventListener('focus', onFocus);
+    window.addEventListener('storage', onStorage);
+
+    return () => {
+      clearTimers();
+      window.removeEventListener('focus', onFocus);
+      window.removeEventListener('storage', onStorage);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [leadSeconds, minInterval]);
+}

--- a/frontend/src/layouts/DashboardLayout.jsx
+++ b/frontend/src/layouts/DashboardLayout.jsx
@@ -2,6 +2,7 @@
 import { Outlet, Link, useNavigate, useLocation } from 'react-router-dom';
 import { useEffect, useState, useCallback } from 'react';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
+import TokenBadge from '../components/auth/TokenBadge';
 
 export default function DashboardLayout({ handleLogout }) {
   const navigate = useNavigate();
@@ -184,25 +185,31 @@ export default function DashboardLayout({ handleLogout }) {
           background: '#111827',
           color: '#e5e7eb',
           padding: '16px 12px',
-          position: 'sticky',     // clave: sidebar fijo en scroll
+          position: 'sticky',
           top: 0,
-          height: '100dvh',       // ocupa alto completo
+          height: '100dvh',
           boxSizing: 'border-box',
-          overflow: 'hidden',     // el nav interno hará scroll
+          overflow: 'hidden',
         }}
       >
-        <h2 className="sidebar-brand" style={{ margin: 0 }}>
-          CitaFácil
-        </h2>
+        <div>
+          <h2 className="sidebar-brand" style={{ margin: 0 }}>
+            CitaFácil
+          </h2>
+          {/* TokenBadge (solo dev) */}
+          <div style={{ marginTop: 8 }}>
+            <TokenBadge />
+          </div>
+        </div>
 
         <nav
           className="sidebar-nav"
           style={{
             marginTop: 12,
             flex: 1,
-            overflowY: 'auto',      // el contenido del menú hace scroll
+            overflowY: 'auto',
             minHeight: 0,
-            paddingRight: 4,           // evitar “pegar” el scroll al borde
+            paddingRight: 4,
           }}
         >
           <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
@@ -219,7 +226,7 @@ export default function DashboardLayout({ handleLogout }) {
         <div
           className="sidebar-footer"
           style={{
-            position: 'sticky',     // clave: se “pega” al fondo visible
+            position: 'sticky',
             bottom: 0,
             background: '#111827',
             paddingTop: 10,
@@ -272,7 +279,7 @@ export default function DashboardLayout({ handleLogout }) {
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'space-between',
-                marginBottom: 16,
+                marginBottom: 8,
               }}
             >
               <h2 className="sidebar-brand" style={{ margin: 0 }}>
@@ -291,6 +298,11 @@ export default function DashboardLayout({ handleLogout }) {
               >
                 <XMarkIcon width={22} height={22} />
               </button>
+            </div>
+
+            {/* TokenBadge también en móvil */}
+            <div style={{ marginBottom: 8 }}>
+              <TokenBadge />
             </div>
 
             <nav className="sidebar-nav" style={{ flex: 1, overflowY: 'auto' }}>

--- a/frontend/src/layouts/PublicLayout.jsx
+++ b/frontend/src/layouts/PublicLayout.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Link, Outlet } from 'react-router-dom';
 import Button from '../components/ui/Button';
 import Footer from './Footer';
+import TokenBadge from '../components/auth/TokenBadge';
 
 const PublicLayout = ({ token, handleLogout }) => {
   return (
@@ -11,13 +12,16 @@ const PublicLayout = ({ token, handleLogout }) => {
       <header className="bg-white shadow-sm sticky top-0 z-40">
         <nav className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
-            {/* Logo o Nombre de la App */}
-            <Link
-              to="/"
-              className="text-2xl font-semibold text-brand-500 hover:text-brand-600 hover:underline"
-            >
-              CitaFácil
-            </Link>
+            {/* Marca + estado del token (solo dev) */}
+            <div className="flex items-center gap-2">
+              <Link
+                to="/"
+                className="text-2xl font-semibold text-brand-500 hover:text-brand-600 hover:underline"
+              >
+                CitaFácil
+              </Link>
+              <TokenBadge />
+            </div>
 
             {/* Botones Condicionales */}
             <div className="flex items-center space-x-4">

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -1,5 +1,5 @@
-// frontend/src/services/apiClient.js
-import { API_BASE, authFetch } from '../api/http';
+// src/services/apiClient.js
+import { API_BASE, authFetch, clearTokens } from '../api/http';
 
 /**
  * Convierte un objeto de params en querystring.
@@ -28,7 +28,6 @@ function buildQuery(params = {}) {
  */
 function normalizeOptions(extra) {
   if (!extra) return { params: null, headers: {} };
-  // Si parece options shape nueva
   if (typeof extra === 'object' && ('params' in extra || 'headers' in extra)) {
     return {
       params: extra.params || null,
@@ -42,15 +41,10 @@ function normalizeOptions(extra) {
 /**
  * Cliente genérico para el backend.
  * - Usa authFetch (añade Authorization y reintenta con refresh_token si hay 401).
- * - Soporta body JSON automáticamente salvo en GET.
+ * - Soporta body JSON automáticamente salvo en GET y soporta FormData.
  * - Soporta params de query vía 4º argumento: apiClient('/path', 'GET', null, { params:{...} })
  * - Devuelve JSON si el servidor lo envía; si no, intenta texto. Para 204, null.
- *
- * @param {string} endpoint - Ruta relativa (con o sin '/')
- * @param {string} method   - 'GET' | 'POST' | 'PUT' | 'DELETE' ...
- * @param {any}    body     - objeto JSON o FormData (si FormData, no se fuerza Content-Type)
- * @param {object} extra    - (opcional) { params?: Record<string,any>, headers?: Record<string,string> }
- *                            // Compat: también puede ser directamente un objeto headers
+ * - Si tras el refresh persiste un 401, limpia tokens y redirige a /login?next=...
  */
 export async function apiClient(endpoint, method = 'GET', body = null, extra = undefined) {
   const { params, headers: extraHeaders } = normalizeOptions(extra);
@@ -60,7 +54,6 @@ export async function apiClient(endpoint, method = 'GET', body = null, extra = u
   const url = `${API_BASE}${cleanEndpoint}${query}`;
 
   const headers = new Headers({
-    // No fijamos Content-Type si el body es FormData
     ...(body instanceof FormData ? {} : { 'Content-Type': 'application/json' }),
     ...(extraHeaders || {}),
   });
@@ -84,21 +77,23 @@ export async function apiClient(endpoint, method = 'GET', body = null, extra = u
   let data = null;
 
   if (ctype.includes('application/json')) {
-    try {
-      data = await res.json();
-    } catch {
-      data = null;
-    }
+    try { data = await res.json(); } catch { data = null; }
   } else {
-    // Si no es JSON, intenta devolver texto (útil para endpoints simples)
-    try {
-      data = await res.text();
-    } catch {
-      data = null;
-    }
+    try { data = await res.text(); } catch { data = null; }
   }
 
   if (!res.ok) {
+    // Redirección a login si queda 401 después del intento de refresh
+    if (res.status === 401) {
+      const isAuthEndpoint = cleanEndpoint.startsWith('/auth') || cleanEndpoint.includes('/auth/');
+      const onLoginPage = window.location.pathname.startsWith('/login');
+      if (!isAuthEndpoint && !onLoginPage) {
+        try { clearTokens(); } catch {}
+        const next = encodeURIComponent(window.location.pathname + window.location.search);
+        window.location.replace(`/login?next=${next}`);
+      }
+    }
+
     const msg =
       (data && (data.msg || data.error || data.detail)) ||
       `${res.status} ${res.statusText}`;


### PR DESCRIPTION
## Resumen
- Backend:
  - /api/auth/login ahora devuelve también `refresh_token`.
  - /api/auth/oauth/google devuelve `access_token` + `refresh_token`.
  - /api/auth/phone/verify-otp devuelve `access_token` + `refresh_token`.
  - /api/auth/refresh protegido con `@jwt_required(refresh=True)` genera un nuevo `access_token`.
  - Config: soporte de expiraciones vía env:
    - JWT_ACCESS_TOKEN_EXPIRES (por defecto 3600s)
    - JWT_REFRESH_TOKEN_EXPIRES (por defecto 30 días)
- Frontend:
  - Cliente HTTP central (`src/api/http.js`) con refresh silencioso:
    - Reintenta 1 vez si recibe 401 usando `refresh_token`.
    - Sincroniza claves `access_token`/`accessToken` y `refresh_token`/`refreshToken`.
  - `apiClient` usa `authFetch` y soporta `params` para querystring.
  - `authService` y `otpService` guardan ambos tokens (access/refresh).
  - `ProtectedRoute` comprueba expiración y fuerza refresh/redirect si falla.
  - `AdminMetricsPage` adaptado (sin `ensureTokenSync` y usando imports nuevos).
  - `App.jsx` normaliza tokens al montar y propaga cambios vía `storage` event.
  - `TokenBadge` de depuración SOLO visible en `development`.

## Archivos clave
- backend/app/routes/auth.py
- backend/config.py
- frontend/src/api/http.js
- frontend/src/services/apiClient.js
- frontend/src/services/authService.js
- frontend/src/services/otpService.js
- frontend/src/components/auth/ProtectedRoute.jsx
- frontend/src/pages/Login.jsx
- frontend/src/api/adminMetrics.js
- frontend/src/pages/AdminMetricsPage.jsx
- frontend/src/App.jsx
- frontend/src/layouts/PublicLayout.jsx (oculta badge en prod)
- frontend/src/layouts/DashboardLayout.jsx (sin cambios funcionales)

## Cómo probar (rápido)
### Backend (curl)
1) Login:
   curl -s -X POST http://localhost:5001/api/auth/login -H 'Content-Type: application/json' \
     -d '{"email":"miuser@demo.com","password":"MiClaveSegura123!"}'
   → Debe devolver `access_token` y `refresh_token`.

2) Refresh:
   curl -i -X POST http://localhost:5001/api/auth/refresh \
     -H "Authorization: Bearer <REFRESH_TOKEN>"
   → 200 + `access_token` nuevo.

3) Google OAuth:
   curl -i -X POST http://localhost:5001/api/auth/oauth/google \
     -H 'Content-Type: application/json' \
     -d '{"token":"<credential de Google>"}'
   → 200 + ambos tokens.

4) Phone OTP:
   - request-otp: POST /api/auth/phone/request-otp
   - verify-otp:  POST /api/auth/phone/verify-otp
   → verify devuelve ambos tokens.

### Frontend
- Arrancar Vite, login normal y navegar a rutas protegidas.
- Expirar/limpiar el `access_token` y confirmar que el refresh se hace silencioso.
- En `development`, el badge de token aparece; en producción, no.

## Notas
- El badge de sesión es *solo dev* (no visible en prod).
- Si en el endpoint /auth/magic aún no devolvemos `refresh_token`, el FE ya contempla ambos casos. Podemos añadirlo en una PR posterior si se desea.

3) Checklist de verificación rápida
 .env backend con:

JWT_ACCESS_TOKEN_EXPIRES y JWT_REFRESH_TOKEN_EXPIRES (opcional).

CORS permite http://localhost:5173 (ya lo tienes).

 Login (email/pass) entrega ambos tokens.

 Google y Phone OTP idem.

 /api/auth/refresh válido con refresh token.

 Navegación a rutas protegidas funciona y renueva token cuando expira.

 En prod, no se ve el TokenBadge.