### PR TITLE
feat(auth): email verification banner with resend + cooldown and dismiss

### DIFF
--- a/frontend/src/components/auth/EmailVerificationBanner.jsx
+++ b/frontend/src/components/auth/EmailVerificationBanner.jsx
@@ -1,0 +1,105 @@
+// src/components/auth/EmailVerificationBanner.jsx
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { resendEmailVerification } from '../../services/authService';
+import { getClientProfile } from '../../services/clientService';
+import { getProviderProfile } from '../../services/providerService';
+
+export default function EmailVerificationBanner() {
+  const [visible, setVisible] = useState(false);
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [cooldown, setCooldown] = useState(0);
+
+  // Carga de estado (una sola vez): si email existe y no está verificado -> mostrar banner
+  useEffect(() => {
+    const dismissedUntil = Number(sessionStorage.getItem('email_verif_banner_hide_until') || '0');
+    if (Date.now() < dismissedUntil) return;
+
+    const role = localStorage.getItem('userRole');
+    const load = async () => {
+      try {
+        let prof;
+        if (role === 'client') {
+          prof = await getClientProfile();
+        } else if (role === 'provider') {
+          prof = await getProviderProfile();
+        } else {
+          return; // sin rol, nada que mostrar
+        }
+
+        // Normalizamos posibles formas del objeto
+        const e = prof?.email || prof?.user?.email || '';
+        const verified = (prof?.email_verified ?? prof?.user?.email_verified) || false;
+        const autogen = e && e.endsWith('@autogen.local');
+
+        setEmail(e);
+        setVisible(Boolean(e) && !autogen && !verified);
+      } catch {
+        // silencio: si no podemos cargar perfil, no molestamos
+      }
+    };
+
+    load();
+  }, []);
+
+  // Cuenta atrás para el botón "Reenviar"
+  useEffect(() => {
+    if (!cooldown) return;
+    const id = setInterval(() => {
+      setCooldown(s => (s <= 1 ? (clearInterval(id), 0) : s - 1));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [cooldown]);
+
+  const onResend = async () => {
+    setLoading(true);
+    try {
+      await resendEmailVerification();
+      toast.success('Te hemos enviado un email de verificación.');
+      setCooldown(30); // evita spam durante 30s
+    } catch (e) {
+      toast.error(e?.message || 'No se pudo enviar el correo ahora');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const dismiss = (minutes = 120) => {
+    const until = Date.now() + minutes * 60 * 1000;
+    sessionStorage.setItem('email_verif_banner_hide_until', String(until));
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="mb-4 rounded-md border border-amber-300 bg-amber-50 text-amber-900 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="font-medium">Verifica tu correo</div>
+          <div className="text-sm">
+            Tu correo <span className="font-mono">{email}</span> aún no está verificado.
+            Revisa tu bandeja de entrada o solicita un nuevo email.
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onResend}
+            disabled={loading || cooldown > 0}
+            className="rounded bg-amber-600 px-3 py-1.5 text-white text-sm disabled:opacity-60"
+          >
+            {cooldown > 0 ? `Reenviar (${cooldown})` : (loading ? 'Enviando…' : 'Reenviar')}
+          </button>
+          <button
+            onClick={() => dismiss(120)}
+            className="rounded border px-3 py-1.5 text-sm"
+            aria-label="Ocultar recordatorio"
+          >
+            Ocultar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/layouts/DashboardLayout.jsx
+++ b/frontend/src/layouts/DashboardLayout.jsx
@@ -3,6 +3,7 @@ import { Outlet, Link, useNavigate, useLocation } from 'react-router-dom';
 import { useEffect, useState, useCallback } from 'react';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 import TokenBadge from '../components/auth/TokenBadge';
+import EmailVerificationBanner from '../components/auth/EmailVerificationBanner';
 
 export default function DashboardLayout({ handleLogout }) {
   const navigate = useNavigate();
@@ -350,6 +351,7 @@ export default function DashboardLayout({ handleLogout }) {
           overflowX: 'clip',
         }}
       >
+        <EmailVerificationBanner />
         <Outlet />
       </main>
     </div>

--- a/frontend/src/layouts/PublicLayout.jsx
+++ b/frontend/src/layouts/PublicLayout.jsx
@@ -5,6 +5,7 @@ import { Link, Outlet } from 'react-router-dom';
 import Button from '../components/ui/Button';
 import Footer from './Footer';
 import TokenBadge from '../components/auth/TokenBadge';
+import EmailVerificationBanner from '../components/auth/EmailVerificationBanner';
 
 const PublicLayout = ({ token, handleLogout }) => {
   return (
@@ -51,6 +52,7 @@ const PublicLayout = ({ token, handleLogout }) => {
 
       {/* El main crece y empuja el footer abajo */}
       <main className="flex-grow">
+      {token ? <EmailVerificationBanner /> : null}
         <Outlet />
       </main>
 


### PR DESCRIPTION
Resumen

Este PR introduce un banner de verificación de email en el dashboard (y, opcionalmente, en el layout público con sesión iniciada) que:

Detecta si el usuario tiene email_verified === false.

Muestra una notificación con el email actual del usuario.

Incluye un botón "Reenviar" que llama al endpoint POST /api/auth/email/resend-verification.

Aplica un temporizador (cooldown) de 30 segundos para evitar spam.

Permite al usuario ocultar el banner durante 2 horas (el estado se persiste en sessionStorage).

Justificación

Aunque el perfil del usuario ya indica el estado "no verificado", este banner:

Proporciona visibilidad proactiva en todas las páginas privadas.

Simplifica el proceso de reenvío, ya que el usuario no necesita navegar a la página de perfil.

Contribuye a reducir las incidencias relacionadas con cuentas no verificadas.

Alcance

Este PR se limita al frontend. No se crean ni se modifican endpoints; solo se reutilizan los siguientes:

GET /client/profile o GET /provider/profile: para verificar si la propiedad email_verified es false.

POST /auth/email/resend-verification: para reenviar el email de verificación.

Cambios Propuestos

Nuevo archivo: frontend/src/components/auth/EmailVerificationBanner.jsx

Modificación: frontend/src/layouts/DashboardLayout.jsx → Renderiza el componente <EmailVerificationBanner /> antes de <Outlet />.

Modificación (opcional): frontend/src/layouts/PublicLayout.jsx → Renderiza <EmailVerificationBanner /> si el token de sesión está presente. (Puedes eliminar este cambio si no deseas que el banner aparezca en las páginas públicas).

Funcionamiento

El componente lee el userRole de localStorage y, basándose en el rol, carga el perfil (getClientProfile() o getProviderProfile()).

El banner se muestra solo si el usuario tiene un email válido (que no termine en @autogen.local) y su estado de email_verified es false.

Al hacer clic en "Reenviar", se llama a resendEmailVerification() y se deshabilita el botón por 30 segundos.

Al hacer clic en "Ocultar", se guarda una marca de tiempo en sessionStorage (email_verif_banner_hide_until) que mantiene el banner oculto durante 120 minutos.

Configuración / Entorno

No se requieren cambios. El PR utiliza tus endpoints actuales.

Seguridad y Límite de Tasa

La llamada para reenviar el email de verificación exige un token JWT (jwt_required) para su autenticación.

Si lo consideras necesario, puedes implementar un límite de tasa en el backend para el endpoint /auth/email/resend-verification (por IP o por usuario).

Plan de Pruebas

Inicia sesión con una cuenta de usuario que no esté verificada (con un email real, no @autogen.local).

Navega al dashboard. El banner de verificación debe ser visible.

Haz clic en el botón "Reenviar". Debe aparecer una notificación de éxito (toast) y el botón debe quedar deshabilitado por 30 segundos.

Haz clic en el botón "Ocultar". El banner debe desaparecer. Recarga la página para confirmar que permanece oculto durante aproximadamente 2 horas.

Verifica el email haciendo clic en el enlace recibido. Después de recargar la página, el banner ya no debería aparecer.

Capturas de Pantalla

(Adjunta capturas de pantalla si es necesario)

Lista de Verificación

El banner solo se muestra cuando la cuenta no está verificada y tiene un email real.

Reutiliza los servicios existentes (clientService, providerService, authService).

No causa rupturas en la navegación ni en los estilos de la interfaz.

No implica cambios en el backend ni nuevas migraciones de base de datos.