### PR TITLE
feat(profile): add ChangePasswordCard to Client & Provider; wire to authService.changePassword

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -557,3 +557,57 @@ def forgot_password():
         current_app.logger.error(f"[forgot-password] Error inesperado: {e}", exc_info=True)
         # Aun así mantenemos respuesta genérica 200 (anti-enumeración)
         return jsonify({"msg": "Si el correo existe, te hemos enviado instrucciones para restablecer la contraseña."}), 200
+
+
+@bp.route('/change-password', methods=['POST'])
+@jwt_required()
+@limiter.limit("5 per 10 minutes")
+def change_password():
+    """
+    Permite a un usuario autenticado cambiar su contraseña.
+    Body: { "current_password": "...", "new_password": "..." }
+    - Si el usuario no tenía contraseña (ej. alta por Google/phone), current_password puede venir vacío.
+    """
+    try:
+        data = request.get_json(silent=True) or {}
+        current = (data.get('current_password') or '').strip()
+        new = (data.get('new_password') or '').strip()
+
+        if not new or len(new) < 8:
+            return jsonify({"msg": "La nueva contraseña debe tener al menos 8 caracteres"}), 400
+
+        # Identidad del token
+        try:
+            user_id = int(get_jwt_identity())
+        except (TypeError, ValueError):
+            return jsonify({"msg": "Identidad del token inválida"}), 422
+
+        user = User.query.get(user_id)
+        if not user:
+            return jsonify({"msg": "Usuario no encontrado"}), 404
+
+        # ¿Tenía contraseña previa?
+        had_password = True
+        try:
+            # Si tu modelo guarda hash vacío/None para usuarios sociales, check_password debe manejarlo
+            had_password = bool(user.password_hash)
+        except Exception:
+            # fallback conservador
+            had_password = True
+
+        if had_password:
+            # Requiere current_password correcto
+            if not current:
+                return jsonify({"msg": "Debes indicar tu contraseña actual"}), 400
+            if not user.check_password(current):
+                return jsonify({"msg": "La contraseña actual no es correcta"}), 400
+        # Si no tenía contraseña (alta por Google/phone), permitimos establecerla sin current
+
+        user.set_password(new)
+        db.session.commit()
+        return jsonify({"msg": "Contraseña actualizada correctamente"}), 200
+
+    except Exception as e:
+        current_app.logger.error(f"change_password error: {e}", exc_info=True)
+        db.session.rollback()
+        return jsonify({"msg": "No se pudo actualizar la contraseña"}), 500

--- a/frontend/src/components/auth/ChangePasswordCard.jsx
+++ b/frontend/src/components/auth/ChangePasswordCard.jsx
@@ -1,0 +1,86 @@
+//src/components/auth/ChangePasswordCard.js
+import { useState } from 'react';
+import Button from '../ui/Button';
+import Input from '../ui/Input';
+import { changePassword } from '../../services/authService';
+import toast from 'react-hot-toast';
+
+export default function ChangePasswordCard() {
+  const [currentPwd, setCurrentPwd] = useState('');
+  const [newPwd, setNewPwd] = useState('');
+  const [confirmPwd, setConfirmPwd] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    if (!newPwd || newPwd.length < 8) {
+      toast.error('La nueva contraseña debe tener al menos 8 caracteres');
+      return;
+    }
+    if (newPwd !== confirmPwd) {
+      toast.error('Las contraseñas no coinciden');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await changePassword(currentPwd, newPwd);
+      toast.success('Contraseña actualizada');
+      setCurrentPwd('');
+      setNewPwd('');
+      setConfirmPwd('');
+    } catch (err) {
+      toast.error(err?.message || 'No se pudo actualizar la contraseña');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+      <h3 className="text-base font-semibold text-gray-800">Cambiar contraseña</h3>
+      <p className="text-sm text-gray-500 mb-3">
+        Establece una nueva contraseña para tu cuenta.
+      </p>
+      <form onSubmit={onSubmit} className="space-y-3 max-w-md">
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Contraseña actual</label>
+          <Input
+            type="password"
+            value={currentPwd}
+            onChange={(e) => setCurrentPwd(e.target.value)}
+            placeholder="••••••••"
+            disabled={submitting}
+          />
+          <p className="text-xs text-gray-400 mt-1">
+            Si entraste con Google o teléfono y nunca definiste una contraseña, deja este campo vacío.
+          </p>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Nueva contraseña</label>
+          <Input
+            type="password"
+            value={newPwd}
+            onChange={(e) => setNewPwd(e.target.value)}
+            placeholder="Mín. 8 caracteres"
+            required
+            disabled={submitting}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Confirmar nueva contraseña</label>
+          <Input
+            type="password"
+            value={confirmPwd}
+            onChange={(e) => setConfirmPwd(e.target.value)}
+            placeholder="Repite la nueva contraseña"
+            required
+            disabled={submitting}
+          />
+        </div>
+        <Button type="submit" variant="primary" disabled={submitting}>
+          {submitting ? 'Guardando…' : 'Actualizar contraseña'}
+        </Button>
+      </form>
+    </section>
+  );
+}

--- a/frontend/src/pages/ClientProfile.jsx
+++ b/frontend/src/pages/ClientProfile.jsx
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react';
 import { getClientProfile } from '../services/clientService';
 import ClientInfoCard from '../components/ClientInfoCard';
+import ChangePasswordCard from '../components/auth/ChangePasswordCard';
 
 function ClientProfile() {
   const [profile, setProfile] = useState(null);
@@ -26,8 +27,21 @@ function ClientProfile() {
     setProfile(updatedUser);
   };
 
-  if (loading) return <div className="page-wrapper"><p>Cargando perfil...</p></div>;
-  if (error) return <div className="page-wrapper"><p className="error-message">{error}</p></div>;
+  if (loading) {
+    return (
+      <div className="page-wrapper">
+        <p>Cargando perfil...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="page-wrapper">
+        <p className="error-message">{error}</p>
+      </div>
+    );
+  }
 
   return (
     <div className="page-wrapper">
@@ -37,8 +51,9 @@ function ClientProfile() {
             <h1>Mi Perfil</h1>
             <p>Hola, {profile.first_name || 'usuario'}. Aquí puedes gestionar tus datos.</p>
           </header>
-          <main className="profile-content">
+          <main className="profile-content space-y-6">
             <ClientInfoCard profile={profile} onProfileUpdate={handleProfileUpdate} />
+            <ChangePasswordCard />
           </main>
         </>
       ) : (

--- a/frontend/src/pages/ProviderProfile.jsx
+++ b/frontend/src/pages/ProviderProfile.jsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { getProviderProfile } from '../services/providerService';
 import GeneralInfoCard from '../components/GeneralInfoCard.jsx';
 import TaxInfoCard from '../components/TaxInfoCard.jsx';
+import ChangePasswordCard from '../components/auth/ChangePasswordCard.jsx';
 
 function ProviderProfile() {
   const [profile, setProfile] = useState(null);
@@ -77,6 +78,11 @@ function ProviderProfile() {
         />
         {/* Info fiscal */}
         <TaxInfoCard profile={profile} />
+
+        {/* Cambiar contraseña - ocupa ancho completo */}
+        <div className="lg:col-span-2">
+          <ChangePasswordCard />
+        </div>
       </main>
     </div>
   );

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -55,3 +55,7 @@ export async function redeemMagicToken(token) {
 export function resendEmailVerification() {
   return apiClient(`${AUTH}/email/resend-verification`, 'POST');
 }
+
+export function changePassword(current_password, new_password) {
+  return apiClient('/auth/change-password', 'POST', { current_password, new_password });
+}


### PR DESCRIPTION
### Qué incluye
- Nuevo componente `ChangePasswordCard.jsx` (UI minimalista con validaciones básicas).
- Inserción del card en:
  - `ClientProfile.jsx`
  - `ProviderProfile.jsx`
- Nueva función `changePassword(current_password, new_password)` en `authService.js` que llama a `POST /api/auth/change-password` vía `apiClient`.

### Notas
- La UI está lista y conectada al servicio; requiere que el backend exponga `POST /api/auth/change-password` (JWT-required).
  - Payload esperado: `{ current_password, new_password }`
  - Respuesta esperada: `200 OK` en éxito, error JSON con `msg` en fallo.
- El campo “Contraseña actual” puede dejarse vacío para cuentas creadas por Google/Phone si el backend lo permite.

### Pruebas
1. Iniciar sesión como `client` o `provider`.
2. Ir a `/dashboard/.../profile`.
3. En el bloque “Cambiar contraseña”:
   - Si `new_password` < 8 chars → toast de error.
   - Si confirmación no coincide → toast de error.
   - En éxito → toast “Contraseña actualizada” y limpieza de inputs.

### Archivos cambiados
- `frontend/src/components/auth/ChangePasswordCard.jsx` (nuevo)
- `frontend/src/pages/ClientProfile.jsx`
- `frontend/src/pages/ProviderProfile.jsx`
- `frontend/src/services/authService.js`

### Checklist
- [x] Compila en Vite.
- [x] Sin cambios de estilos globales.
- [x] Respeta el flujo de refresh silencioso (usa `apiClient`).
