### PR TITLE
feat(auth): wire AuthProvider in main.jsx (global session state via /auth/me)

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,80 @@
+// frontend/src/context/AuthContext.jsx
+import { createContext, useContext, useEffect, useRef, useState } from 'react';
+import { apiClient } from '../services/apiClient';
+import { getAccessToken, clearTokens } from '../api/http';
+
+const AuthCtx = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [me, setMe] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const inFlight = useRef(false);
+
+  async function fetchMe() {
+    const at = getAccessToken();
+    if (!at) {
+      setMe(null);
+      setLoading(false);
+      setError('');
+      return;
+    }
+    if (inFlight.current) return;
+    inFlight.current = true;
+    setLoading(true);
+    setError('');
+    try {
+      const data = await apiClient('/auth/me', 'GET');
+      setMe(data ?? null);
+    } catch (e) {
+      // Si /me falla (p. ej. 401 tras refresh), considera sesión caída
+      setMe(null);
+      setError(e?.message || 'No se pudo obtener el perfil');
+    } finally {
+      setLoading(false);
+      inFlight.current = false;
+    }
+  }
+
+  // 1) cargar al montar
+  useEffect(() => {
+    fetchMe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 2) reintentar cuando cambie el access_token (mismo tab)
+  useEffect(() => {
+    const onStorage = (ev) => {
+      if (ev.key === 'access_token' || ev.key === 'accessToken') {
+        fetchMe();
+      }
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const logout = () => {
+    try { clearTokens(); } catch {}
+    setMe(null);
+    setError('');
+  };
+
+  const value = {
+    me,
+    setMe,
+    loading,
+    error,
+    isAuthenticated: Boolean(me?.user_id),
+    logout,
+    reload: fetchMe,
+  };
+
+  return <AuthCtx.Provider value={value}>{children}</AuthCtx.Provider>;
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthCtx);
+  if (!ctx) throw new Error('useAuth must be used within <AuthProvider>');
+  return ctx;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,20 +5,22 @@ import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import { BookingProvider } from './context/BookingContext.jsx';
 import { GoogleOAuthProvider } from '@react-oauth/google';
+import { AuthProvider } from './context/AuthContext.jsx';
 
 // Estilos globales
-import './index.css'; // Para Tailwind
-import './App.css';   // Para TODOS tus estilos personalizados
+import './index.css';
+import './App.css';
 
-
-const GOOGLE_CLIENT_ID = "618642945850-i4rekbfl4g49760m2jb11rocvnf29ji4.apps.googleusercontent.com";
+const GOOGLE_CLIENT_ID = '618642945850-i4rekbfl4g49760m2jb11rocvnf29ji4.apps.googleusercontent.com';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
-      <BookingProvider>
-        <App />
-      </BookingProvider>
+      <AuthProvider>
+        <BookingProvider>
+          <App />
+        </BookingProvider>
+      </AuthProvider>
     </GoogleOAuthProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
Resumen
Esta PR integra el AuthProvider global en el punto de entrada de la aplicación (main.jsx) para que todas las rutas y layouts puedan consumir la información de la sesión (me, isAuthenticated, logout, reload) desde una única fuente de verdad.

¿Qué cambió?
Se envuelve <App /> con:

GoogleOAuthProvider (externo)

AuthProvider (medio)

BookingProvider (interno)

No hay cambios funcionales en otras partes del código. Esto permite futuras refactorizaciones para leer me.role / me.email_verified sin depender de localStorage.

¿Por qué?
Centralizar el estado de autenticación: Se obtiene /auth/me una sola vez y se comparte en todo el árbol de componentes.

Prepararse para eliminar lecturas dispersas de localStorage y mejorar la experiencia de usuario en caso de sesiones expiradas.

¿Cómo probarlo?
Inicia sesión de forma habitual (correo electrónico+contraseña, Google, magic link o OTP por teléfono).

Abre las herramientas de desarrollador > Application > Local Storage y borra access_token para simular la expiración, o espera a que expire. Verifica que la aplicación maneje la autenticación de forma correcta a través del proveedor (puedes seguir navegando por las páginas públicas; las protegidas estarán resguardadas por ProtectedRoute y las futuras refactorizaciones leerán useAuth()).

Opcional: Llama a GET /api/auth/me manualmente para verificar que el backend devuelve la carga útil (payload) esperada.