### PR TITLE
feat(auth): ProtectedRoute via AuthProvider + dashboard index by me.role

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,10 @@
 // src/App.jsx
-import { useState, useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate, Link } from 'react-router-dom';
 import { Toaster } from 'react-hot-toast';
 
 import PublicLayout from './layouts/PublicLayout';
 import DashboardLayout from './layouts/DashboardLayout.jsx';
+import ProtectedRoute from './components/auth/ProtectedRoute';
 
 import BrowsePage from './pages/BrowsePage';
 import Login from './pages/Login';
@@ -23,7 +23,6 @@ import BookingPage from './pages/BookingPage';
 import ConfirmBookingPage from './pages/ConfirmBookingPage';
 import BookingSuccessPage from './pages/BookingSuccessPage';
 import ClientAppointments from './pages/ClientAppointments';
-import ProtectedRoute from './components/auth/ProtectedRoute';
 import ProviderAppointments from './pages/ProviderAppointments';
 import ProviderDashboard from './pages/ProviderDashboard';
 import ManageStaff from './pages/ManageStaff';
@@ -33,66 +32,26 @@ import Magic from './pages/Magic';
 import LoginPhone from './pages/LoginPhone';
 import ProviderWhatsAppQR from './pages/ProviderWhatsAppQR';
 import AdminMetricsPage from "./pages/AdminMetricsPage";
-import useProactiveRefresh from './hooks/useProactiveRefresh';
-import useAuthMe from './hooks/useAuthMe';
 
-function App() {
-  const [token, setToken] = useState(
-    localStorage.getItem('accessToken') || localStorage.getItem('access_token')
-  );
+import { useAuth } from './context/AuthContext';
 
-  // 👉 Nuevo: cargamos me desde /auth/me
-  const { me, loading: meLoading, refreshMe } = useAuthMe();
+// Decide índice de dashboard por rol
+function DashboardIndex() {
+  const { me } = useAuth();
+  if (me?.role === 'provider') return <ProviderDashboard />;
+  return <ClientDashboard />;
+}
 
-  // --- SHIM: sincroniza accessToken <-> access_token al montar ---
-  useEffect(() => {
-    try {
-      const t1 = localStorage.getItem('accessToken');
-      const t2 = localStorage.getItem('access_token');
-      const chosen = t1 || t2;
-      if (chosen) {
-        if (t1 !== chosen) localStorage.setItem('accessToken', chosen);
-        if (t2 !== chosen) localStorage.setItem('access_token', chosen);
-        setToken(chosen);
-        window.dispatchEvent(new Event('storage'));
-      }
-    } catch (e) {
-      console.debug('App init: storage not available', e);
-    }
-  }, []);
-
-  // escucha cambios de storage para mantener estado en sync
-  useEffect(() => {
-    const handleStorageChange = () => {
-      setToken(localStorage.getItem('accessToken') || localStorage.getItem('access_token'));
-      // useAuthMe ya reacciona y recarga /auth/me
-    };
-    window.addEventListener('storage', handleStorageChange);
-    return () => window.removeEventListener('storage', handleStorageChange);
-  }, []);
-
-  const handleLogin = (newToken, _newRole) => {
-    localStorage.setItem('accessToken', newToken);
-    localStorage.setItem('access_token', newToken);
-    setToken(newToken);
-    // dispara storage -> useAuthMe recarga /auth/me
-    window.dispatchEvent(new Event('storage'));
-  };
-
-  const handleLogout = () => {
-    localStorage.removeItem('accessToken');
-    localStorage.removeItem('access_token');
-    localStorage.removeItem('userRole'); // legacy
-    setToken(null);
-    window.dispatchEvent(new Event('storage'));
-  };
+export default function App() {
+  const { isAuthenticated } = useAuth();
 
   return (
     <Router>
       <Toaster position="top-right" toastOptions={{ duration: 5000 }} />
+
       <Routes>
-        {/* --- GRUPO 1: RUTAS PÚBLICAS --- */}
-        <Route element={<PublicLayout me={me} token={token} handleLogout={handleLogout} />}>
+        {/* --- RUTAS PÚBLICAS --- */}
+        <Route element={<PublicLayout />}>
           <Route path="/" element={<BrowsePage />} />
           <Route path="/login-phone" element={<LoginPhone />} />
           <Route path="/magic" element={<Magic />} />
@@ -100,61 +59,54 @@ function App() {
           <Route path="/booking/success" element={<BookingSuccessPage />} />
         </Route>
 
-        {/* --- GRUPO 2: RUTAS DE AUTENTICACIÓN --- */}
-        <Route path="/login" element={!token ? <Login onLogin={handleLogin} /> : <Navigate to="/dashboard" />} />
-        <Route path="/register" element={!token ? <Register /> : <Navigate to="/dashboard" />} />
-        <Route path="/register/provider" element={!token ? <RegisterProvider /> : <Navigate to="/dashboard" />} />
+        {/* --- AUTENTICACIÓN --- */}
+        <Route
+          path="/login"
+          element={!isAuthenticated ? <Login /> : <Navigate to="/dashboard" replace />}
+        />
+        <Route
+          path="/register"
+          element={!isAuthenticated ? <Register /> : <Navigate to="/dashboard" replace />}
+        />
+        <Route
+          path="/register/provider"
+          element={!isAuthenticated ? <RegisterProvider /> : <Navigate to="/dashboard" replace />}
+        />
         <Route path="/reset-password/:token" element={<NewPasswordForm />} />
         <Route path="/register/reset-password" element={<ResetPassword />} />
 
-        {/* --- GRUPO 3: RUTAS PROTEGIDAS --- */}
-        <Route element={<ProtectedRoute token={token} />}>
+        {/* --- RUTAS PROTEGIDAS --- */}
+        <Route element={<ProtectedRoute />}>
           <Route path="/booking/confirm" element={<ConfirmBookingPage />} />
-          <Route path="/dashboard" element={<DashboardLayout handleLogout={handleLogout} me={me} />}>
-            {/* índice condicional según me.role */}
-            <Route
-              index
-              element={
-                meLoading ? (
-                  <div className="p-6 text-sm text-slate-500">Cargando…</div>
-                ) : me?.role === 'provider' ? (
-                  <ProviderDashboard />
-                ) : (
-                  <ClientDashboard />
-                )
-              }
-            />
+          <Route path="/dashboard" element={<DashboardLayout />}>
+            <Route index element={<DashboardIndex />} />
 
             {/* PROVEEDOR */}
-            {me?.role === 'provider' && (
-              <Route path="provider">
-                <Route path="profile" element={<ProviderProfile />} />
-                <Route path="establishments" element={<ManageEstablishments />} />
-                <Route path="establishments/new" element={<CreateEstablishment />} />
-                <Route path="establishments/edit/:establishmentId" element={<EditEstablishment />} />
-                <Route path="services" element={<ManageServices />} />
-                <Route path="availability" element={<ManageAvailability />} />
-                <Route path="appointments" element={<ProviderAppointments />} />
-                <Route path="staff" element={<ManageStaff />} />
-                <Route path="staff/availability" element={<ManageStaffAvailability />} />
-                <Route path="whatsapp-qr" element={<ProviderWhatsAppQR />} />
-                <Route path="admin/metrics" element={<AdminMetricsPage />} />
-              </Route>
-            )}
+            <Route path="provider">
+              <Route path="profile" element={<ProviderProfile />} />
+              <Route path="establishments" element={<ManageEstablishments />} />
+              <Route path="establishments/new" element={<CreateEstablishment />} />
+              <Route path="establishments/edit/:establishmentId" element={<EditEstablishment />} />
+              <Route path="services" element={<ManageServices />} />
+              <Route path="availability" element={<ManageAvailability />} />
+              <Route path="appointments" element={<ProviderAppointments />} />
+              <Route path="staff" element={<ManageStaff />} />
+              <Route path="staff/availability" element={<ManageStaffAvailability />} />
+              <Route path="whatsapp-qr" element={<ProviderWhatsAppQR />} />
+              <Route path="admin/metrics" element={<AdminMetricsPage />} />
+            </Route>
 
             {/* CLIENTE */}
-            {me?.role === 'client' && (
-              <Route path="client">
-                <Route path="profile" element={<ClientProfile />} />
-                <Route path="appointments" element={<ClientAppointments />} />
-              </Route>
-            )}
+            <Route path="client">
+              <Route path="profile" element={<ClientProfile />} />
+              <Route path="appointments" element={<ClientAppointments />} />
+            </Route>
 
             <Route path="*" element={<NotFoundDashboard />} />
           </Route>
         </Route>
 
-        {/* RUTA COMODÍN FINAL */}
+        {/* COMODÍN */}
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </Router>
@@ -177,5 +129,3 @@ const NotFoundPage = () => (
     <Link to="/" style={{ color: '#4f46e5', textDecoration: 'underline' }}>Volver a la página de inicio</Link>
   </div>
 );
-
-export default App;

--- a/frontend/src/components/auth/ProtectedRoute.jsx
+++ b/frontend/src/components/auth/ProtectedRoute.jsx
@@ -1,15 +1,30 @@
-// src/components/auth/ProtectedRoute.jsx
-import { Outlet, Navigate, useLocation } from 'react-router-dom';
-import { getAccessToken, getRefreshToken } from '../../api/http';
+// frontend/src/components/auth/ProtectedRoute.jsx
+import { useEffect } from 'react';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
 
 export default function ProtectedRoute() {
   const location = useLocation();
-  const at = getAccessToken();
-  const rt = getRefreshToken();
+  const { isAuthenticated, loading, reload } = useAuth();
 
-  // Si hay access o refresh, deja pasar: los fetch protegidos harán refresh si hace falta.
-  if (at || rt) return <Outlet />;
+  useEffect(() => {
+    // Al entrar en una zona protegida, revalida estado (me + refresh silencioso si caducó)
+    reload();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  // Sin ningún token -> a login con “next”
-  return <Navigate to="/login" state={{ from: location }} replace />;
+  if (loading) {
+    return (
+      <div className="min-h-[40vh] flex items-center justify-center">
+        <div className="animate-pulse text-sm text-slate-500">Comprobando sesión…</div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    const next = encodeURIComponent(`${location.pathname}${location.search || ''}`);
+    return <Navigate to={`/login?next=${next}`} replace />;
+  }
+
+  return <Outlet />;
 }

--- a/frontend/src/layouts/DashboardLayout.jsx
+++ b/frontend/src/layouts/DashboardLayout.jsx
@@ -4,13 +4,13 @@ import { useEffect, useState, useCallback } from 'react';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 import TokenBadge from '../components/auth/TokenBadge';
 import EmailVerificationBanner from '../components/auth/EmailVerificationBanner';
+import { useAuth } from '../context/AuthContext';
 
-export default function DashboardLayout({ handleLogout, me }) {
+export default function DashboardLayout() {
   const navigate = useNavigate();
   const location = useLocation();
-
-  // 🔁 Ahora el rol viene de `me`, no de localStorage
-  const userRole = me?.role || null;
+  const { me, logout } = useAuth(); // ← usamos el contexto
+  const role = me?.role;
 
   const [isMobile, setIsMobile] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -43,10 +43,10 @@ export default function DashboardLayout({ handleLogout, me }) {
   }, [drawerOpen]);
 
   const onLogoutClick = useCallback(() => {
-    handleLogout();
-    navigate('/login');
+    logout();                // ← del contexto
+    navigate('/login', { replace: true });
     setDrawerOpen(false);
-  }, [handleLogout, navigate]);
+  }, [logout, navigate]);
 
   const getLinkStyle = (path) => {
     const isActivePath = (target) => {
@@ -79,7 +79,7 @@ export default function DashboardLayout({ handleLogout, me }) {
       transition: 'background-color 0.2s ease-in-out',
     };
 
-    if (userRole === 'provider') {
+    if (role === 'provider') {
       return (
         <>
           <li>
@@ -118,7 +118,7 @@ export default function DashboardLayout({ handleLogout, me }) {
       );
     }
 
-    if (userRole === 'client') {
+    if (role === 'client') {
       return (
         <>
           <li>
@@ -357,5 +357,6 @@ export default function DashboardLayout({ handleLogout, me }) {
         <Outlet />
       </main>
     </div>
-  );
+    );
 }
+


### PR DESCRIPTION
Resumen
Esta PR elimina las verificaciones de localStorage/efectos secundarios en el enrutamiento protegido y adopta el estado del AuthProvider global.

ProtectedRoute.jsx:
Usa useAuth() (isAuthenticated, loading, reload).

Desencadena reload() al montarse → obtiene /auth/me y se apoya en http.js para un refresco silencioso.

Redirige a /login?next=... cuando no está autenticado; muestra un estado de carga ligero mientras resuelve la autenticación.

App.jsx:
Introduce el componente DashboardIndex para elegir entre el dashboard del proveedor o del cliente a través de me.role.

Deja de pasar token/handleLogout a los layouts (ya usan useAuth() internamente).

¿Por qué?
Una única fuente de verdad para la sesión (/auth/me), lo que reduce las condiciones de carrera y la duplicación.

Nos prepara para eliminar el estado de token/role de App.jsx y migrar Login.jsx para que notifique al contexto en lugar de manipular localStorage directamente.

¿Cómo probarlo?
Inicia sesión (correo electrónico+contraseña / Google / OTP / magic link).

Navega a /dashboard y asegúrate de que las rutas se renderizan correctamente.

Borra el access_token en localStorage y vuelve a navegar. ProtectedRoute debería recargar, refrescarse silenciosamente y mantenerte en la sesión.

Expira los tokens manualmente o detén el refresco para verificar que se redirige a /login?next=....