### PR TITLE
feat(auth): modernize ProtectedRoute to rely on AuthContext (me/isAuthenticated/meLoading)

### DIFF
--- a/frontend/src/components/auth/ProtectedRoute.jsx
+++ b/frontend/src/components/auth/ProtectedRoute.jsx
@@ -1,19 +1,13 @@
 // frontend/src/components/auth/ProtectedRoute.jsx
-import { useEffect } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 
 export default function ProtectedRoute() {
+  const { isAuthenticated, meLoading } = useAuth();
   const location = useLocation();
-  const { isAuthenticated, loading, reload } = useAuth();
 
-  useEffect(() => {
-    // Al entrar en una zona protegida, revalida estado (me + refresh silencioso si caducó)
-    reload();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  if (loading) {
+  // Mientras resolvemos /auth/me, enseñamos un pequeño loader
+  if (meLoading) {
     return (
       <div className="min-h-[40vh] flex items-center justify-center">
         <div className="animate-pulse text-sm text-slate-500">Comprobando sesión…</div>
@@ -21,8 +15,9 @@ export default function ProtectedRoute() {
     );
   }
 
+  // Si no está autenticado, redirigimos a login con next
   if (!isAuthenticated) {
-    const next = encodeURIComponent(`${location.pathname}${location.search || ''}`);
+    const next = encodeURIComponent(location.pathname + location.search);
     return <Navigate to={`/login?next=${next}`} replace />;
   }
 


### PR DESCRIPTION
Resumen:

Reemplaza ProtectedRoute para que dependa del AuthContext (isAuthenticated/meLoading).

Muestra un loader mientras /auth/me se resuelve.

Redirige a /login?next=... cuando no hay sesión.

Evita duplicar lógica de tokens/refresh en componentes; todo queda centralizado en AuthContext + http.js.