### PR TITLE
feat(auth): register → redirect to /login?next=… + standardize RegisterProvider styles

### DIFF
--- a/frontend/src/pages/GoogleLoginComponent.jsx
+++ b/frontend/src/pages/GoogleLoginComponent.jsx
@@ -7,18 +7,11 @@ const GoogleLoginComponent = ({ onLogin }) => {
   const [error, setError] = useState(null);
 
   const handleSuccess = (credentialResponse) => {
-    // La respuesta de Google ya nos da el token que necesita nuestro backend.
-    const googleToken = credentialResponse.credential;
-    console.log('Google Token recibido:', googleToken);
-    
-    if (onLogin) {
-      // Llamamos a la función que nos pasaron con el token.
-      onLogin(googleToken);
-    }
+    const googleToken = credentialResponse?.credential;
+    if (googleToken && onLogin) onLogin(googleToken);
   };
 
   const handleError = () => {
-    console.error('Google login failed');
     setError('Error al iniciar sesión con Google.');
   };
 
@@ -27,9 +20,10 @@ const GoogleLoginComponent = ({ onLogin }) => {
       <GoogleLogin
         onSuccess={handleSuccess}
         onError={handleError}
+        ux_mode="popup"
         useOneTap
       />
-      {error && <p style={{ color: 'red', marginTop: '10px' }}>{error}</p>}
+      {error && <p className="mt-2 text-sm text-rose-600">{error}</p>}
     </div>
   );
 };

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -2,10 +2,13 @@
 import { useState } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import toast from 'react-hot-toast';
+
 import { loginUser, loginWithGoogle } from '../services/authService';
-import GoogleLoginComponent from "./GoogleLoginComponent";
+import GoogleLoginComponent from './GoogleLoginComponent';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
+
+import { setAccessToken, setRefreshToken } from '../api/http';
 import { useAuth } from '../context/AuthContext';
 
 // Util: decodifica el JWT (solo payload)
@@ -21,6 +24,17 @@ function decodeJwt(token) {
   }
 }
 
+// Next seguro: solo rutas internas que empiecen por "/" (y no "//")
+function getSafeNext(location) {
+  const sp = new URLSearchParams(location.search);
+  const fromState = location.state?.from?.pathname;
+  const candidate = sp.get('next') || fromState;
+  if (typeof candidate === 'string' && candidate.startsWith('/') && !candidate.startsWith('//')) {
+    return candidate;
+  }
+  return '/dashboard';
+}
+
 export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -28,50 +42,48 @@ export default function Login() {
 
   const navigate = useNavigate();
   const location = useLocation();
-  const { refreshMe } = useAuth(); // 👈 clave
+  const { refreshMe } = useAuth();
 
-  const persistAuth = (accessToken, refreshToken, role) => {
-    // Guardamos en ambas claves por compat (métricas/legacy)
+  const persistTokens = (accessToken, refreshToken) => {
     if (accessToken) {
-      localStorage.setItem('access_token', accessToken);
-      localStorage.setItem('accessToken', accessToken);
+      setAccessToken(accessToken);
+      // opcional: guardar exp por si quieres mostrar contadores
       const a = decodeJwt(accessToken);
       if (a?.exp) localStorage.setItem('access_exp', String(a.exp));
     }
     if (refreshToken) {
-      localStorage.setItem('refresh_token', refreshToken);
-      localStorage.setItem('refreshToken', refreshToken);
+      setRefreshToken(refreshToken);
       const r = decodeJwt(refreshToken);
       if (r?.exp) localStorage.setItem('refresh_exp', String(r.exp));
     }
-    // (opcional) legacy
-    if (role) localStorage.setItem('userRole', role);
-
-    // Disparar un "storage" sintético para oyentes en esta misma pestaña
-    try { window.dispatchEvent(new Event('storage')); } catch {}
+    // compat legacy para código viejo que aún lee userRole (no imprescindible)
+    // si el backend lo devuelve en /auth/login:
+    // localStorage.setItem('userRole', role || '');
   };
 
-  const redirectAfterLogin = () => {
-    const nextFromQuery = new URLSearchParams(location.search).get('next');
-    const fromState = location.state?.from?.pathname;
-    const target = nextFromQuery || fromState || '/dashboard';
-    navigate(target, { replace: true });
+  const redirectAfterLogin = async () => {
+    // Traemos /auth/me antes de navegar para que ProtectedRoute y el layout
+    // ya tengan me listo y no “reboten”.
+    try {
+      await refreshMe();
+    } catch {
+      // si falla, navegamos igual; ProtectedRoute intentará refrescar luego
+    }
+    const next = getSafeNext(location);
+    navigate(next, { replace: true });
   };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setSubmitting(true);
     try {
-      const data = await loginUser(email, password); // {access_token, refresh_token, role, ...}
-      persistAuth(data.access_token, data.refresh_token, data.role);
-
-      // 🔁 Pedimos el /auth/me actualizado antes de navegar
-      await refreshMe();
-
+      // /auth/login → { access_token, refresh_token, role, ... }
+      const data = await loginUser(email, password);
+      persistTokens(data?.access_token, data?.refresh_token);
       toast.success('¡Bienvenido/a de nuevo!');
-      redirectAfterLogin();
+      await redirectAfterLogin();
     } catch (error) {
-      toast.error(error?.message || "Error al iniciar sesión.");
+      toast.error(error?.message || 'Error al iniciar sesión.');
     } finally {
       setSubmitting(false);
     }
@@ -81,14 +93,11 @@ export default function Login() {
     setSubmitting(true);
     try {
       const data = await loginWithGoogle(googleToken);
-      persistAuth(data.access_token, data.refresh_token, data.role);
-
-      await refreshMe();
-
+      persistTokens(data?.access_token, data?.refresh_token);
       toast.success('¡Bienvenido/a de nuevo!');
-      redirectAfterLogin();
+      await redirectAfterLogin();
     } catch (error) {
-      toast.error(error?.message || "Error en el inicio con Google.");
+      toast.error(error?.message || 'Error en el inicio con Google.');
     } finally {
       setSubmitting(false);
     }
@@ -146,18 +155,12 @@ export default function Login() {
             </p>
             <p>
               ¿Eres proveedor?{' '}
-              <Link
-                to="/register/provider"
-                className="font-semibold text-brand-500 hover:underline"
-              >
+              <Link to="/register/provider" className="font-semibold text-brand-500 hover:underline">
                 Regístrate como proveedor
               </Link>
             </p>
             <p>
-              <Link
-                to="/register/reset-password"
-                className="font-semibold text-brand-500 hover:underline"
-              >
+              <Link to="/register/reset-password" className="font-semibold text-brand-500 hover:underline">
                 ¿Olvidaste tu contraseña?
               </Link>
             </p>

--- a/frontend/src/pages/LoginPhone.jsx
+++ b/frontend/src/pages/LoginPhone.jsx
@@ -7,7 +7,7 @@ import Input from '../components/ui/Input';
 import Button from '../components/ui/Button';
 import { getLastPhone, setLastPhone } from '../utils/phoneMemory';
 
-// Util: decodifica el JWT (solo payload)
+// Decode JWT (payload)
 function decodeJwt(token) {
   if (!token) return null;
   const parts = token.split('.');
@@ -20,35 +20,49 @@ function decodeJwt(token) {
   }
 }
 
+// next seguro (solo rutas internas que empiezan por "/")
+function getSafeNext(searchParams) {
+  const candidate = searchParams.get('next');
+  if (typeof candidate === 'string' && candidate.startsWith('/') && !candidate.startsWith('//')) {
+    return candidate;
+  }
+  return '/dashboard';
+}
+
 export default function LoginPhone() {
   const [step, setStep] = useState('phone'); // 'phone' | 'code'
   const [phone, setPhone] = useState('');
   const [code, setCode] = useState('');
   const [loading, setLoading] = useState(false);
+
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
 
-  const next = searchParams.get('next') || '/';
-  const inviteError = searchParams.get('error'); // p.ej. invalid_invite
+  const next = getSafeNext(searchParams);
+  const inviteError = searchParams.get('error'); // e.g. invalid_invite
   const autoSend = searchParams.get('send') === '1';
 
   const lastPhone = useMemo(() => getLastPhone() || '', []);
 
-  // Guarda tokens/role en localStorage (ambas claves para compatibilidad)
+  // Persist tokens (compat) + avisar al AuthContext
   const persistAuth = (accessToken, refreshToken, role) => {
-    if (accessToken) {
-      localStorage.setItem('access_token', accessToken);
-      localStorage.setItem('accessToken', accessToken);
-      const a = decodeJwt(accessToken);
-      if (a?.exp) localStorage.setItem('access_exp', String(a.exp));
-    }
-    if (refreshToken) {
-      localStorage.setItem('refresh_token', refreshToken);
-      localStorage.setItem('refreshToken', refreshToken);
-      const r = decodeJwt(refreshToken);
-      if (r?.exp) localStorage.setItem('refresh_exp', String(r.exp));
-    }
-    if (role) localStorage.setItem('userRole', role);
+    try {
+      if (accessToken) {
+        localStorage.setItem('access_token', accessToken);
+        localStorage.setItem('accessToken', accessToken);
+        const a = decodeJwt(accessToken);
+        if (a?.exp) localStorage.setItem('access_exp', String(a.exp));
+      }
+      if (refreshToken) {
+        localStorage.setItem('refresh_token', refreshToken);
+        localStorage.setItem('refreshToken', refreshToken);
+        const r = decodeJwt(refreshToken);
+        if (r?.exp) localStorage.setItem('refresh_exp', String(r.exp));
+      }
+      if (role) localStorage.setItem('userRole', role);
+      // 🔔 Notificar a AuthContext (escucha el evento 'storage')
+      window.dispatchEvent(new Event('storage'));
+    } catch {}
   };
 
   const onRequest = async (e) => {
@@ -62,18 +76,16 @@ export default function LoginPhone() {
     try {
       const res = await requestPhoneOtp(normalized);
 
-      // Guarda el último teléfono usado para UX
       setLastPhone(normalized);
       setStep('code');
 
       if (res?.debug_code) {
-        // En dev, autocompleta el input para facilitar la prueba
         setCode(res.debug_code);
         toast.success(`Código enviado. (DEV: ${res.debug_code})`);
 
-        // Si viene verify=1 en la URL y tenemos el code, auto-verificamos
         if (searchParams.get('verify') === '1') {
-          await onVerify(); // llama sin evento
+          // Auto-verificar en dev si se pide con ?verify=1
+          await onVerify(); // sin evento
           return;
         }
       } else {
@@ -96,28 +108,25 @@ export default function LoginPhone() {
     }
     setLoading(true);
     try {
-      // ⬇️ IMPORTANTE: asegúrate de que tu backend devuelva también refresh_token y role
-      // Respuesta esperada: { access_token, refresh_token, role, profile_complete, ... }
+      // Backend debe devolver: { access_token, refresh_token, role, profile_complete, ... }
       const data = await verifyPhoneOtp(normalized, code.trim());
 
-      // Persistimos sesión
+      // Persistir sesión y avisar contexto
       persistAuth(data.access_token, data.refresh_token, data.role);
-      // Guardamos el teléfono tras verificar correctamente
       setLastPhone(normalized);
 
       toast.success('Sesión iniciada');
 
       // Redirección:
-      // - Si el perfil no está completo, te mando al perfil cliente
-      // - Si está completo, voy a "next" (o home) respetando el query param
+      // - Si el perfil no está completo → perfil cliente
+      // - Si está completo → next (seguro) o dashboard
       if (!data?.profile_complete) {
         navigate('/dashboard/client/profile', { replace: true });
       } else {
         navigate(next, { replace: true });
       }
     } catch (err) {
-      const msg = err?.message || 'No se pudo verificar el código';
-      toast.error(msg);
+      toast.error(err?.message || 'No se pudo verificar el código');
     } finally {
       setLoading(false);
     }
@@ -133,11 +142,9 @@ export default function LoginPhone() {
       })();
       setPhone(decoded);
       if (autoSend) {
-        // envía OTP automáticamente
-        onRequest();
+        onRequest(); // envía OTP automáticamente
       }
     } else if (lastPhone) {
-      // Si no viene en la URL, intentamos recuperar el último teléfono recordado
       setPhone(lastPhone);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/pages/Magic.jsx
+++ b/frontend/src/pages/Magic.jsx
@@ -1,7 +1,18 @@
+// frontend/src/pages/Magic.jsx
+
 import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import toast from "react-hot-toast";
 import { redeemMagicToken } from "../services/authService";
+
+// next seguro: solo rutas internas
+function getSafeNext(searchParams) {
+  const raw = searchParams.get("next");
+  if (typeof raw === "string" && raw.startsWith("/") && !raw.startsWith("//")) {
+    return raw;
+  }
+  return "/dashboard";
+}
 
 export default function Magic() {
   const [searchParams] = useSearchParams();
@@ -10,7 +21,8 @@ export default function Magic() {
 
   useEffect(() => {
     const token = searchParams.get("token");
-    const next = searchParams.get("next") || "/"; // permite /magic?token=...&next=/booking
+    const next = getSafeNext(searchParams);
+
     if (!token) {
       toast.error("Falta el token");
       setStatus("error");
@@ -20,17 +32,24 @@ export default function Magic() {
 
     (async () => {
       try {
-        // ⬇️ ahora leemos profile_complete del backend
+        // El backend devuelve { access_token, refresh_token, profile_complete, ... }
         const { profile_complete } = await redeemMagicToken(token);
+
+        // Notificar cambios de storage al mismo tab (AuthContext escucha este evento)
+        try {
+          window.dispatchEvent(new Event("storage"));
+        } catch {}
+
         setStatus("ok");
 
-        // Si el perfil está incompleto, forzamos completar perfil primero
         const target = profile_complete ? next : "/dashboard/client/profile";
-
-        // redirige tras 500ms para que el usuario vea el estado un instante
+        // pequeña pausa para que el usuario vea el estado
         setTimeout(() => navigate(target, { replace: true }), 500);
       } catch (err) {
-        const msg = err?.response?.data?.msg || "Enlace inválido o caducado";
+        const msg =
+          err?.response?.data?.msg ||
+          err?.message ||
+          "Enlace inválido o caducado";
         toast.error(msg);
         setStatus("error");
         navigate("/login", { replace: true });

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,12 +1,20 @@
-// frontend/src/pages/Register.jsx
-
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { registerUser } from '../services/authService';
 import Input from '../components/ui/Input';
 import Button from '../components/ui/Button';
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
+
+// Solo permitimos rutas internas que empiecen por "/"
+function getSafeNext(location) {
+  const sp = new URLSearchParams(location.search);
+  const candidate = sp.get('next');
+  if (typeof candidate === 'string' && candidate.startsWith('/') && !candidate.startsWith('//')) {
+    return candidate;
+  }
+  return '/dashboard';
+}
 
 function Register() {
   const [formData, setFormData] = useState({
@@ -17,12 +25,13 @@ function Register() {
     phone_number: ''
   });
   const [showPassword, setShowPassword] = useState(false);
-
-  const navigate = useNavigate();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  const navigate = useNavigate();
+  const location = useLocation();
+
   const handleChange = (e) => {
-    setFormData({ ...formData, [e.target.name]: e.target.value });
+    setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
   };
 
   const handleSubmit = async (e) => {
@@ -36,13 +45,12 @@ function Register() {
     setIsSubmitting(true);
     try {
       const data = await registerUser(formData);
-      toast.success(data.msg || '¡Registro exitoso! Revisa tu email para validar la cuenta.');
-
-      setTimeout(() => {
-        navigate('/login');
-      }, 2500);
+      toast.success(data?.msg || '¡Registro exitoso! Revisa tu email para validar la cuenta.');
+      const next = getSafeNext(location);
+      // Conservamos el destino: al llegar a login, se usará para post-login
+      navigate(`/login?next=${encodeURIComponent(next)}`, { replace: true });
     } catch (err) {
-      toast.error(err.message || 'Ocurrió un error durante el registro.');
+      toast.error(err?.message || 'Ocurrió un error durante el registro.');
     } finally {
       setIsSubmitting(false);
     }
@@ -83,7 +91,7 @@ function Register() {
               required
             />
 
-            {/* Campo contraseña con mostrar/ocultar */}
+            {/* Contraseña con mostrar/ocultar */}
             <div className="relative">
               <Input
                 type={showPassword ? 'text' : 'password'}
@@ -92,11 +100,11 @@ function Register() {
                 value={formData.password}
                 onChange={handleChange}
                 required
-                className="pr-11" // deja espacio al icono
+                className="pr-11"
               />
               <button
                 type="button"
-                onClick={() => setShowPassword((v) => !v)}
+                onClick={() => setShowPassword(v => !v)}
                 aria-label={showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
                 className="absolute inset-y-0 right-2 my-auto inline-flex items-center justify-center text-gray-500 hover:text-gray-700 focus:ring-brand-500"
               >
@@ -114,7 +122,7 @@ function Register() {
 
             <div className="pt-2 flex justify-center">
               <Button type="submit" variant="primary" disabled={isSubmitting}>
-                {isSubmitting ? 'Registrando...' : 'Registrarse'}
+                {isSubmitting ? 'Registrando…' : 'Registrarse'}
               </Button>
             </div>
           </form>

--- a/frontend/src/pages/RegisterProvider.jsx
+++ b/frontend/src/pages/RegisterProvider.jsx
@@ -1,11 +1,20 @@
-// frontend/src/pages/RegisterProvider.jsx
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { registerProvider } from '../services/authService';
 import Input from '../components/ui/Input';
 import Button from '../components/ui/Button';
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
+
+// Solo rutas internas
+function getSafeNext(location) {
+  const sp = new URLSearchParams(location.search);
+  const candidate = sp.get('next');
+  if (typeof candidate === 'string' && candidate.startsWith('/') && !candidate.startsWith('//')) {
+    return candidate;
+  }
+  return '/dashboard';
+}
 
 function RegisterProvider() {
   const [formData, setFormData] = useState({
@@ -26,7 +35,9 @@ function RegisterProvider() {
 
   const [showPassword, setShowPassword] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
   const navigate = useNavigate();
+  const location = useLocation();
 
   const handleChange = (e) => {
     setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
@@ -51,11 +62,12 @@ function RegisterProvider() {
       };
 
       const data = await registerProvider(apiData);
-      toast.success(data.msg || '¡Proveedor registrado! Revisa tu email para validar la cuenta.');
+      toast.success(data?.msg || '¡Proveedor registrado! Revisa tu email para validar la cuenta.');
 
-      setTimeout(() => navigate('/login'), 2000);
+      const next = getSafeNext(location);
+      navigate(`/login?next=${encodeURIComponent(next)}`, { replace: true });
     } catch (err) {
-      toast.error(err.message || 'Ocurrió un error durante el registro.');
+      toast.error(err?.message || 'Ocurrió un error durante el registro.');
     } finally {
       setIsSubmitting(false);
     }
@@ -63,13 +75,13 @@ function RegisterProvider() {
 
   return (
     <div className="auth-page">
-      <div className="login-container register-provider-container">
-        <header className="login-header">
-          <h1>Registro para Proveedores</h1>
-          <p>Crea tu perfil y empieza a gestionar tus citas</p>
-        </header>
+      <div className="login-container">
+        <main className="login-box max-w-3xl">
+          <header className="login-header">
+            <h1>Registro para Proveedores</h1>
+            <p>Crea tu perfil y empieza a gestionar tus citas</p>
+          </header>
 
-        <main className="login-box max-w-3xl w-full mx-auto p-8 rounded-lg shadow-lg bg-white">
           <form onSubmit={handleSubmit} className="space-y-8 text-left">
             {/* Datos del Negocio */}
             <fieldset className="bg-gray-50 p-6 rounded-lg border border-gray-200 space-y-4">
@@ -147,7 +159,7 @@ function RegisterProvider() {
               />
             </fieldset>
 
-            {/* Datos de Contacto */}
+            {/* Datos de Contacto y Cuenta */}
             <fieldset className="bg-gray-50 p-6 rounded-lg border border-gray-200 space-y-4">
               <legend className="text-lg font-semibold text-gray-800">Datos de Contacto y Cuenta</legend>
 
@@ -176,11 +188,7 @@ function RegisterProvider() {
                   aria-label={showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
                   className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
                 >
-                  {showPassword ? (
-                    <EyeSlashIcon className="h-5 w-5" />
-                  ) : (
-                    <EyeIcon className="h-5 w-5" />
-                  )}
+                  {showPassword ? <EyeSlashIcon className="h-5 w-5" /> : <EyeIcon className="h-5 w-5" />}
                 </button>
               </div>
 
@@ -220,9 +228,11 @@ function RegisterProvider() {
               </div>
             </fieldset>
 
-            <Button type="submit" variant="secondary" disabled={isSubmitting}>
-              {isSubmitting ? 'Creando cuenta…' : 'Crear cuenta de proveedor'}
-            </Button>
+            <div className="pt-2 flex justify-center">
+              <Button type="submit" variant="primary" disabled={isSubmitting}>
+                {isSubmitting ? 'Creando cuenta…' : 'Crear cuenta de proveedor'}
+              </Button>
+            </div>
           </form>
 
           <footer className="login-footer mt-6">


### PR DESCRIPTION
Resumen:
A veces, tras iniciar sesión, ProtectedRoute “rebotaba” porque el estado de sesión aún no estaba cargado.

El login y el registro debían respetar ?next=/ruta-interna, ignorando destinos externos para evitar open redirects.

Queremos una UX coherente en formularios (tarjeta blanca, mostrar/ocultar contraseña, estados de envío) y que el login por teléfono respete también ?next y actualice el estado global.

Qué cambia
Autenticación y navegación

Login (email/password):

Persiste tokens con utilidades de http.js (setAccessToken/setRefreshToken).

Llama a await refreshMe() antes de navegar para evitar parpadeos/rebotes en ProtectedRoute.

Respeta ?next sanitizado (solo rutas internas que empiezan por /); si no es válido → fallback a /dashboard.

Registro (cliente y proveedor):

Register y RegisterProvider leen un next seguro y redirigen a /login?next=... tras completar el registro.

Se unifica la UX: tarjeta blanca, mostrar/ocultar contraseña, textos y estados de envío consistentes.

RegisterProvider adopta el mismo look & feel (tarjeta blanca con fieldset).

Login por teléfono (LoginPhone):

Respeta ?next seguro.

Persiste access/refresh y dispara window.storage para que AuthContext refresque /auth/me.

Mantiene flujos de dev (debug_code, verify=1), prefill por ?phone= o memoria local.

GoogleLoginComponent:

Modo popup para una UX más suave.

Seguridad

Open redirect hardening: next se sanitiza; solo se aceptan rutas internas que:

Empiezan por /

No empiezan por //

No contienen esquema (http://, https://)

Fallback consistente a /dashboard.

Archivos tocados

frontend/src/pages/Login.jsx

frontend/src/pages/Register.jsx

frontend/src/pages/RegisterProvider.jsx

frontend/src/pages/LoginPhone.jsx

frontend/src/components/GoogleLoginComponent.jsx

Nota: Se usan las utilidades de http.js para tokens, no necesariamente modificado en este PR.

Cómo probar (plan manual)

Login con next interno

Navega a /login?next=/dashboard/provider/services

Inicia sesión → aterrizas en /dashboard/provider/services sin rebotes.

Login con next externo

/login?next=https://evil.com → te ignora y redirige a /dashboard.

Login normal (sin next)

Inicia sesión en /login → aterrizas en /dashboard; no debe requerir refresh manual ni “saltos”.

Registro (cliente) con next

/register?next=/dashboard/provider/services

Completa registro → redirige a /login?next=/dashboard/provider/services.

Registro (proveedor) con next

/register/provider?next=/dashboard

Completa registro → /login?next=/dashboard.

Verifica tarjeta blanca, fieldsets y misma UX (mostrar/ocultar contraseña, estados de envío).

Login por teléfono

/login-phone?next=/dashboard/client/appointments&phone=%2B34600000000&send=1 (en dev con debug_code)

Debe autocompletar y verificar.

Si profile_complete=true → navega a next.

Si profile_complete=false → /dashboard/client/profile.

Tokens persistidos y AuthContext actualizado (sin rebotes).

Google login (si aplica)

Probar flujo en popup; confirmar que respeta next seguro y actualiza sesión.

Consola/Lint

No debe haber errores en consola.

lint debe pasar sin warnings críticos.