### PR TITLE
feat(http): robustecer authFetch y refresh; helpers JSON; sync por storage event; Content-Type inteligente

### DIFF
--- a/frontend/src/api/http.js
+++ b/frontend/src/api/http.js
@@ -1,22 +1,29 @@
-// src/api/http.js
+// frontend/src/api/http.js
 const API_BASE = import.meta.env.VITE_API_BASE ?? 'http://localhost:5001/api';
 
+// --- tokens helpers (compat: dos claves) ---
 const getAccessToken = () =>
   localStorage.getItem('access_token') || localStorage.getItem('accessToken');
 
 const getRefreshToken = () =>
   localStorage.getItem('refresh_token') || localStorage.getItem('refreshToken');
 
+const dispatchStorage = () => {
+  try { window.dispatchEvent(new Event('storage')); } catch {}
+};
+
 const setAccessToken = (t) => {
   if (!t) return;
   localStorage.setItem('access_token', t);
   localStorage.setItem('accessToken', t);
+  dispatchStorage();
 };
 
 const setRefreshToken = (t) => {
   if (!t) return;
   localStorage.setItem('refresh_token', t);
   localStorage.setItem('refreshToken', t);
+  dispatchStorage();
 };
 
 const clearTokens = () => {
@@ -24,6 +31,8 @@ const clearTokens = () => {
   localStorage.removeItem('accessToken');
   localStorage.removeItem('refresh_token');
   localStorage.removeItem('refreshToken');
+  localStorage.removeItem('userRole');
+  dispatchStorage();
 };
 
 /** Redirige a /login preservando la ruta actual en ?next= */
@@ -31,15 +40,13 @@ function redirectToLogin() {
   try {
     const here = window.location.pathname + window.location.search;
     const next = encodeURIComponent(here);
-    // Evita bucle si ya estás en /login
     if (!window.location.pathname.startsWith('/login')) {
       window.location.assign(`/login?next=${next}`);
     }
-  } catch {
-    // noop
-  }
+  } catch { /* noop */ }
 }
 
+// --- Refresh (serializado) ---
 let refreshingPromise = null;
 
 async function refreshAccessToken() {
@@ -61,74 +68,148 @@ async function refreshAccessToken() {
         throw new Error(`refresh_${res.status}${detail ? ' - ' + detail : ''}`);
       }
       const data = await res.json();
-      const newAccess = data?.access_token || data?.accessToken || data?.token || null;
+      const newAccess =
+        data?.access_token || data?.accessToken || data?.token || null;
       if (!newAccess) throw new Error('refresh_no_token');
       setAccessToken(newAccess);
       return newAccess;
     })
-    .finally(() => {
-      refreshingPromise = null;
-    });
+    .finally(() => { refreshingPromise = null; });
 
   return refreshingPromise;
 }
 
+// Utilidades de detección de body JSON
+const isFormLike = (b) =>
+  (typeof FormData !== 'undefined' && b instanceof FormData) ||
+  (typeof Blob !== 'undefined' && b instanceof Blob);
+
+const mightBeJsonBody = (method, body) =>
+  method && !['GET','HEAD'].includes(String(method).toUpperCase()) &&
+  body && typeof body === 'object' && !isFormLike(body);
+
+// --- authFetch con reintento tras refresh ---
 async function authFetch(input, init = {}) {
-  // Soporta tanto string como Request
   const reqUrl =
     typeof input === 'string'
       ? input
       : (input && typeof input === 'object' && 'url' in input ? input.url : '');
   const isRefreshCall = reqUrl.includes('/auth/refresh');
 
+  // Construye headers
   const headers = new Headers(init.headers || {});
   const at = getAccessToken();
-  if (at) headers.set('Authorization', `Bearer ${at}`);
-  if (!headers.has('Content-Type')) headers.set('Content-Type', 'application/json');
+  if (at && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${at}`);
+  }
+  if (!headers.has('Accept')) headers.set('Accept', 'application/json');
 
-  const doFetch = (h) =>
-    fetch(input, { ...init, headers: h, credentials: init.credentials ?? 'include' });
+  let body = init.body;
 
-  let res = await doFetch(headers);
+  // Si nos pasan un objeto JS como body en métodos con cuerpo, lo serializamos como JSON
+  if (mightBeJsonBody(init.method, body)) {
+    if (!headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json');
+    }
+    // Evita doble stringify si ya viene string
+    if (typeof body !== 'string') body = JSON.stringify(body);
+  }
 
-  // Si el access_token caducó y NO estamos en el endpoint de refresh, intenta renovar y reintentar 1 vez
-  if (res.status === 401 && !isRefreshCall) {
+  const mkReq = (h, b) => ({
+    ...init,
+    headers: h,
+    body: b,
+    credentials: init.credentials ?? 'include',
+  });
+
+  let res = await fetch(input, mkReq(headers, body));
+
+  // 401/419: intenta un refresh (solo si no estamos ya en /auth/refresh)
+  const shouldTryRefresh =
+    (res.status === 401 || res.status === 419) && !isRefreshCall;
+
+  if (shouldTryRefresh) {
     try {
-      await refreshAccessToken(); // serializa intentos simultáneos
+      await refreshAccessToken(); // serializado entre llamadas
       const headers2 = new Headers(init.headers || {});
       const at2 = getAccessToken();
       if (at2) headers2.set('Authorization', `Bearer ${at2}`);
-      if (!headers2.has('Content-Type')) headers2.set('Content-Type', 'application/json');
-      res = await doFetch(headers2);
+      if (!headers2.has('Accept')) headers2.set('Accept', 'application/json');
+
+      // Reaplica Content-Type solo si sigue siendo JSON “auto”
+      if (mightBeJsonBody(init.method, init.body) && !headers2.has('Content-Type')) {
+        headers2.set('Content-Type', 'application/json');
+      }
+
+      const retryBody =
+        mightBeJsonBody(init.method, init.body) && typeof init.body !== 'string'
+          ? JSON.stringify(init.body)
+          : init.body;
+
+      res = await fetch(input, mkReq(headers2, retryBody));
     } catch {
-      // Falló el refresh → limpiamos credenciales y redirigimos a login
       clearTokens();
       redirectToLogin();
-      return res; // devolvemos el 401 original por si el caller quiere gestionarlo
+      return res; // devolvemos el 401 original
     }
   }
 
   return res;
 }
 
-async function apiGetJson(path) {
-  const res = await authFetch(`${API_BASE}${path}`, { method: 'GET' });
+// --- helpers JSON de conveniencia ---
+async function parseOrThrow(res, verb, path) {
   if (!res.ok) {
     let detail = '';
-    try { detail = await res.text(); } catch {}
-    throw new Error(`GET ${path} ${res.status}: ${detail || res.statusText}`);
+    try {
+      // intenta extraer msg del backend si vino JSON
+      const ct = res.headers.get('content-type') || '';
+      if (ct.includes('application/json')) {
+        const j = await res.json();
+        detail = j?.msg || JSON.stringify(j);
+      } else {
+        detail = await res.text();
+      }
+    } catch {}
+    throw new Error(`${verb} ${path} ${res.status}: ${detail || res.statusText}`);
   }
-  return res.json();
+  const ct = res.headers.get('content-type') || '';
+  if (ct.includes('application/json')) return res.json();
+  // Si no vino JSON, devuelve texto para no romper
+  return res.text();
+}
+
+async function apiGetJson(path, cfg) {
+  const res = await authFetch(`${API_BASE}${path}`, { method: 'GET', ...(cfg || {}) });
+  return parseOrThrow(res, 'GET', path);
+}
+
+async function apiPostJson(path, body, cfg) {
+  const res = await authFetch(`${API_BASE}${path}`, { method: 'POST', body, ...(cfg || {}) });
+  return parseOrThrow(res, 'POST', path);
+}
+
+async function apiPutJson(path, body, cfg) {
+  const res = await authFetch(`${API_BASE}${path}`, { method: 'PUT', body, ...(cfg || {}) });
+  return parseOrThrow(res, 'PUT', path);
+}
+
+async function apiDelete(path, cfg) {
+  const res = await authFetch(`${API_BASE}${path}`, { method: 'DELETE', ...(cfg || {}) });
+  return parseOrThrow(res, 'DELETE', path);
 }
 
 export {
   API_BASE,
   authFetch,
   apiGetJson,
+  apiPostJson,
+  apiPutJson,
+  apiDelete,
   setAccessToken,
   setRefreshToken,
   getAccessToken,
   getRefreshToken,
   clearTokens,
-  refreshAccessToken, 
+  refreshAccessToken,
 };


### PR DESCRIPTION
Resumen:

authFetch ya refrescaba el access token tras 401, pero faltaban algunos detalles: sincronizar el contexto al renovar tokens, evitar forzar Content-Type con FormData, y facilitar llamadas POST/PUT/DELETE con helpers.

También mejoramos la claridad de errores y soportamos códigos como 419 (token expirado).

Qué cambia

🔁 Refresh serializado: mantiene refreshingPromise y reintenta la petición original tras renovar el token (evita carreras).

📣 Sync global por storage: al guardar/borrar access_token/refresh_token se emite window.storage, para que AuthContext revalide /auth/me sin hacks.

🧠 Content-Type inteligente: solo se añade si el body es JSON; no se fuerza con FormData/Blob ni en GET/HEAD.

🧩 Helpers: apiPostJson, apiPutJson, apiDelete + parseOrThrow (mensajes de error más útiles).

🛡️ Tratamiento 401/419 como expiración (evita quedarse “atascado” si el backend usa 419).

🧰 Mantiene compatibilidad con claves duplicadas (access_token/accessToken, etc.).

Archivos cambiados

frontend/src/api/http.js ✅

Cómo probar

Inicia sesión y navega por rutas protegidas.

Expira manualmente el access_token (o espera) y haz una petición cualquiera → debe renovar el token y completarse sin redirigir a login.

Usa un formulario con FormData (subida de avatar/imagen si la tienes) → no debe romperse por Content-Type.

Observa que tras login/refresh/logout el dashboard reacciona (gracias al evento storage).

Fuerza un 401/419 en el backend → debe limpiar tokens y redirigir a /login?next=….

Riesgos / No-regresión

Cambios limitados a la capa HTTP.

No altera contratos de servicios ni rutas.

Revisión manual hecha en navegación básica y llamadas con/ sin body.

Checklist

 Navegación en rutas protegidas OK

 Refresh tras 401/419 OK

 Subidas con FormData OK

 Sin errores en consola

 Lint pasa (si aplica)

Notas

Estos helpers (apiPostJson, apiPutJson, apiDelete) son opt-in; puedes migrar servicios progresivamente.

Si el backend cambia el shape del refresh, solo hay que ajustar la extracción del access_token en un sitio.

ChatGPT puede cometer errores. Considera verificar la información importante. Ver preferencias de cookies.