### PR TITLE
Auto-holidays: cron + configuration UI + blackout validations + agenda with locks

### DIFF
--- a/backend/app/routes/calendar.py
+++ b/backend/app/routes/calendar.py
@@ -450,7 +450,7 @@ def internal_cron_seed_holidays():
         types = set((est.holiday_types or "Public,Bank").split(","))
         years_ahead = est.holiday_years_ahead or 0
 
-        # años objetivo
+        # años objetivo: del año actual hasta el actual + years_ahead (incluido)
         years = range(current_year, current_year + years_ahead + 1)
 
         inserted_sum = skipped_sum = 0

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,6 +34,7 @@ import ProviderWhatsAppQR from './pages/ProviderWhatsAppQR';
 import AdminMetricsPage from "./pages/AdminMetricsPage";
 import RoleRoute from './components/auth/RoleRoute';
 import VerifiedRoute from './components/auth/VerifiedRoute';
+import ProviderHolidaySettings from './pages/ProviderHolidaySettings';
 
 // Auth context
 import { useAuth } from './context/AuthContext';
@@ -108,6 +109,9 @@ export default function App() {
                 <Route path="staff/availability" element={<ManageStaffAvailability />} />
                 <Route path="whatsapp-qr" element={<ProviderWhatsAppQR />} />
                 <Route path="admin/metrics" element={<AdminMetricsPage />} />
+
+                {/* ⚙️ NUEVA RUTA: Ajustes de festivos */}
+                <Route path="holidays" element={<ProviderHolidaySettings />} />
               </Route>
             </Route>
 

--- a/frontend/src/pages/ProviderAppointments.jsx
+++ b/frontend/src/pages/ProviderAppointments.jsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import toast from 'react-hot-toast';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams, useNavigate, Link } from 'react-router-dom';
 import { getAppointmentsForEstablishment } from '../services/establishmentService';
 import { cancelAppointment } from '../services/appointmentService';
 import { getBlackouts, createBlackout, deleteBlackout } from '../services/calendarService';
@@ -345,12 +345,26 @@ const ProviderAppointments = () => {
     <>
       <div className="page-wrapper">
         <header className="page-header">
-          <h1>Agenda de Citas</h1>
-          {establishmentName && (
-            <p>
-              Mostrando agenda para: <strong>{establishmentName}</strong>
-            </p>
-          )}
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h1>Agenda de Citas</h1>
+              {establishmentName && (
+                <p>
+                  Mostrando agenda para: <strong>{establishmentName}</strong>
+                </p>
+              )}
+            </div>
+            {establishmentId && (
+              <Link
+                className="inline-flex items-center rounded-lg border px-3 py-2 text-sm hover:bg-gray-50"
+                to={`/dashboard/provider/holidays?est_id=${encodeURIComponent(
+                  establishmentId
+                )}&name=${encodeURIComponent(establishmentName || '')}`}
+              >
+                Ajustes de festivos
+              </Link>
+            )}
+          </div>
         </header>
 
         <Card>

--- a/frontend/src/pages/ProviderHolidaySettings.jsx
+++ b/frontend/src/pages/ProviderHolidaySettings.jsx
@@ -1,0 +1,179 @@
+// frontend/src/pages/ProviderHolidaySettings.jsx
+import React, { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { useSearchParams } from 'react-router-dom';
+import Card from '../components/ui/Card';
+import Button from '../components/ui/Button';
+import { getEstablishmentPrivate, updateEstablishmentPrivate } from '../services/establishmentService';
+import { seedHolidays } from '../services/calendarService';
+
+const parseTypes = (s) => (s ? s.split(',').map(t => t.trim()).filter(Boolean) : []);
+const typesToString = (arr) => (arr && arr.length ? arr.join(',') : '');
+
+const ProviderHolidaySettings = () => {
+  const [searchParams] = useSearchParams();
+  const establishmentId = searchParams.get('est_id');
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [seeding, setSeeding] = useState(false);
+
+  const [enabled, setEnabled] = useState(false);
+  const [country, setCountry] = useState('ES');
+  const [region, setRegion] = useState(''); // ej: ES-VC
+  const [types, setTypes] = useState(['Public', 'Bank']);
+  const [yearsAhead, setYearsAhead] = useState(1);
+  const [lastSeedYear, setLastSeedYear] = useState(null);
+  const [lastSyncAt, setLastSyncAt] = useState(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!establishmentId) return;
+      setLoading(true);
+      try {
+        const est = await getEstablishmentPrivate(establishmentId);
+        setEnabled(!!est.holiday_auto_enabled);
+        setCountry(est.holiday_country_code || 'ES');
+        setRegion(est.holiday_region_code || '');
+        setTypes(parseTypes(est.holiday_types || 'Public,Bank'));
+        setYearsAhead(est.holiday_years_ahead ?? 1);
+        setLastSeedYear(est.holiday_last_seed_year ?? null);
+        setLastSyncAt(est.holiday_last_sync_at ?? null);
+      } catch (e) {
+        toast.error(e?.response?.data?.msg || 'No se pudo cargar la configuración.');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [establishmentId]);
+
+  const toggleType = (t) => {
+    setTypes(prev => prev.includes(t) ? prev.filter(x => x !== t) : [...prev, t]);
+  };
+
+  const onSave = async () => {
+    if (!establishmentId) return;
+    setSaving(true);
+    try {
+      const payload = {
+        holiday_auto_enabled: !!enabled,
+        holiday_country_code: country || 'ES',
+        holiday_region_code: region || null,
+        holiday_types: typesToString(types.length ? types : ['Public','Bank']),
+        holiday_years_ahead: Number(yearsAhead) || 1,
+      };
+      const est = await updateEstablishmentPrivate(establishmentId, payload);
+      setLastSeedYear(est.holiday_last_seed_year ?? null);
+      setLastSyncAt(est.holiday_last_sync_at ?? null);
+      toast.success('Configuración guardada.');
+    } catch (e) {
+      toast.error(e?.response?.data?.msg || 'No se pudo guardar.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onSeedNow = async () => {
+    if (!establishmentId) return;
+    setSeeding(true);
+    try {
+      const year = new Date().getUTCFullYear();
+      const res = await seedHolidays({
+        establishmentId,
+        country,
+        region: region || undefined,
+        types: typesToString(types),
+        year,
+      });
+      toast.success(`Sembrado: +${res.inserted}, duplicados: ${res.skipped}`);
+      // refrescar metadatos
+      const est = await getEstablishmentPrivate(establishmentId);
+      setLastSeedYear(est.holiday_last_seed_year ?? null);
+      setLastSyncAt(est.holiday_last_sync_at ?? null);
+    } catch (e) {
+      toast.error(e?.response?.data?.msg || 'No se pudo sembrar festivos.');
+    } finally {
+      setSeeding(false);
+    }
+  };
+
+  if (loading) return <div className="page-wrapper"><p>Cargando…</p></div>;
+
+  return (
+    <div className="page-wrapper">
+      <header className="page-header">
+        <h1>Ajustes de Festivos Automáticos</h1>
+        <p className="text-gray-600">Configura cómo bloquear automáticamente los festivos en tu agenda.</p>
+      </header>
+
+      <div className="space-y-6">
+        <Card>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <label className="flex items-center gap-3">
+              <input type="checkbox" checked={enabled} onChange={(e)=>setEnabled(e.target.checked)} />
+              <span>Activar festivos automáticos</span>
+            </label>
+
+            <div>
+              <label className="text-xs text-gray-600">País</label>
+              <select value={country} onChange={(e)=>setCountry(e.target.value)} className="w-full rounded-lg border px-3 py-2 text-sm">
+                <option value="ES">España (ES)</option>
+                {/* añade más países según soporte */}
+              </select>
+            </div>
+
+            <div>
+              <label className="text-xs text-gray-600">Región (opcional)</label>
+              <input
+                type="text"
+                placeholder="ES-VC"
+                value={region}
+                onChange={(e)=>setRegion(e.target.value)}
+                className="w-full rounded-lg border px-3 py-2 text-sm"
+              />
+              <p className="text-xs text-gray-500 mt-1">Ej: ES-VC (Comunitat Valenciana). Déjalo vacío para festivos nacionales.</p>
+            </div>
+
+            <div>
+              <label className="text-xs text-gray-600 block mb-1">Tipos de festivo</label>
+              <div className="flex gap-4">
+                {['Public','Bank'].map(t => (
+                  <label key={t} className="flex items-center gap-2 text-sm">
+                    <input type="checkbox" checked={types.includes(t)} onChange={()=>toggleType(t)} />
+                    <span>{t}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <label className="text-xs text-gray-600">Años por adelantado</label>
+              <select value={yearsAhead} onChange={(e)=>setYearsAhead(Number(e.target.value))} className="w-full rounded-lg border px-3 py-2 text-sm">
+                <option value={1}>1 año</option>
+                <option value={2}>2 años</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="mt-4 flex gap-3">
+            <Button onClick={onSave} disabled={saving}>{saving ? 'Guardando…' : 'Guardar'}</Button>
+            <Button variant="secondary" onClick={onSeedNow} disabled={seeding || !enabled}>
+              {seeding ? 'Sembrando…' : 'Sembrar ahora'}
+            </Button>
+          </div>
+        </Card>
+
+        <Card>
+          <h3 className="text-base font-semibold text-gray-900">Estado</h3>
+          <div className="text-sm text-gray-700 mt-2">
+            <div>Último año sembrado: <strong>{lastSeedYear ?? '—'}</strong></div>
+            <div>Última sincronización: <strong>{lastSyncAt ? new Date(lastSyncAt).toLocaleString() : '—'}</strong></div>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default ProviderHolidaySettings;

--- a/frontend/src/services/calendarService.js
+++ b/frontend/src/services/calendarService.js
@@ -16,24 +16,30 @@ export const getBlackouts = ({ establishmentId, from, to }) => {
 };
 
 /**
- * (Opcional) Festivos automáticos si implementas /api/calendar/holidays en backend.
- * @param {{ country?:string, region?:string, from?:string, to?:string, year?:number }} p
+ * (Opcional) Festivos desde Nager.Date (proxy backend).
+ * @param {{ country?:string, region?:string, from?:string, to?:string, year?:number, types?:string }} p
  * - country por defecto 'ES'
- * - region ejemplo 'VC' (Comunitat Valenciana)
+ * - region ejemplo 'ES-VC' (código Nager de la comunidad)
  * - from/to en "YYYY-MM-DD"
+ * - types ej: "Public,Bank"
  */
-export const getHolidays = ({ country = 'ES', region, from, to, year } = {}) => {
+export const getHolidays = ({ country = 'ES', region, from, to, year, types } = {}) => {
   const params = {
     country,
     ...(region ? { region } : {}),
     ...(from ? { date_from: from } : {}),
     ...(to ? { date_to: to } : {}),
     ...(year ? { year: String(year) } : {}),
+    ...(types ? { types } : {}),
   };
   return apiClient('/calendar/holidays', 'GET', null, { params });
 };
 
-// Crear blackout (requiere sesión de provider)
+/**
+ * Crear blackout (requiere sesión de provider)
+ * - Si isFullDay=true, NO envía start_time/end_time
+ * - Si isFullDay=false, startTime y endTime son obligatorios ("HH:MM")
+ */
 export const createBlackout = ({
   establishmentId,
   date,                // "YYYY-MM-DD"
@@ -41,7 +47,7 @@ export const createBlackout = ({
   startTime,           // "HH:MM" (si isFullDay=false)
   endTime,             // "HH:MM" (si isFullDay=false)
   name,
-  category
+  category,
 }) => {
   const payload = {
     establishment_id: Number(establishmentId),
@@ -54,15 +60,37 @@ export const createBlackout = ({
   return apiClient('/calendar/blackouts', 'POST', payload);
 };
 
+/**
+ * Actualizar blackout (placeholder)
+ * ⚠️ OJO: El backend aún no expone PUT /calendar/blackouts/:id.
+ * Si lo implementas después, esta función quedará lista.
+ */
 export const updateBlackout = (blackoutId, payload) =>
   apiClient(`/calendar/blackouts/${blackoutId}`, 'PUT', payload);
 
+/**
+ * Eliminar blackout (requiere sesión de provider y ser dueño del establecimiento)
+ */
 export const deleteBlackout = (blackoutId) =>
   apiClient(`/calendar/blackouts/${blackoutId}`, 'DELETE');
 
-export const seedHolidays = ({ establishmentId, country='ES', year, region, category='holiday', types='Public,Bank' }) => {
+/**
+ * Sembrar festivos como blackouts de día completo (idempotente en backend)
+ */
+export const seedHolidays = ({
+  establishmentId,
+  country = 'ES',
+  year,
+  region,
+  category = 'holiday',
+  types = 'Public,Bank',
+}) => {
   return apiClient('/calendar/blackouts/seed-holidays', 'POST', {
     establishment_id: Number(establishmentId),
-    country, year, region, category, types,
+    country,
+    year,
+    region,
+    category,
+    types,
   });
 };

--- a/frontend/src/services/establishmentService.js
+++ b/frontend/src/services/establishmentService.js
@@ -2,31 +2,77 @@
 
 import { apiClient } from './apiClient';
 
+/**
+ * Crear establecimiento (panel proveedor)
+ */
 export const createEstablishment = (establishmentData) => {
   return apiClient('/establishments', 'POST', establishmentData);
 };
 
+/**
+ * GET privado de un establecimiento por ID (panel proveedor)
+ * Alias: getEstablishmentPrivate
+ */
 export const getEstablishmentById = (establishmentId) => {
   return apiClient(`/establishments/${establishmentId}`, 'GET');
 };
+export const getEstablishmentPrivate = getEstablishmentById;
 
+/**
+ * PUT privado para actualizar un establecimiento (panel proveedor)
+ * Alias: updateEstablishmentPrivate
+ */
 export const updateEstablishment = (establishmentId, establishmentData) => {
   return apiClient(`/establishments/${establishmentId}`, 'PUT', establishmentData);
 };
+export const updateEstablishmentPrivate = updateEstablishment;
 
+/**
+ * Helper específico para actualizar SOLO ajustes de festivos automáticos.
+ * Evita enviar campos no relacionados.
+ */
+export const updateHolidaySettings = (
+  establishmentId,
+  {
+    holiday_auto_enabled,
+    holiday_country_code,
+    holiday_region_code,
+    holiday_types,
+    holiday_years_ahead,
+  }
+) => {
+  const payload = {
+    ...(typeof holiday_auto_enabled === 'boolean' ? { holiday_auto_enabled } : {}),
+    ...(holiday_country_code ? { holiday_country_code } : {}),
+    // Si la región viene vacía queremos enviar null para limpiarla:
+    ...(holiday_region_code !== undefined ? { holiday_region_code: holiday_region_code || null } : {}),
+    ...(holiday_types ? { holiday_types } : {}),
+    ...(Number.isFinite(holiday_years_ahead) ? { holiday_years_ahead: Number(holiday_years_ahead) } : {}),
+  };
+  return updateEstablishment(establishmentId, payload);
+};
+
+/**
+ * DELETE privado de establecimiento
+ */
 export const deleteEstablishment = (establishmentId) => {
   return apiClient(`/establishments/${establishmentId}`, 'DELETE');
 };
 
+/**
+ * GET público de detalles para la página de reserva
+ */
 export const getPublicEstablishmentDetails = (establishmentId) => {
   return apiClient(`/public/establishments/${establishmentId}`, 'GET');
 };
 
+/**
+ * Horarios disponibles (público). Soporta staff opcional.
+ */
 export const getAvailableSlots = (establishmentId, serviceId, date, staffId = null) => {
   if (!establishmentId || !serviceId || !date) {
     return Promise.reject(new Error('Faltan parámetros para obtener los horarios.'));
   }
-  // usando params del apiClient (si tu apiClient aún no soporta params, deja la versión con query string)
   return apiClient(
     `/establishments/${establishmentId}/available-slots`,
     'GET',
@@ -41,10 +87,16 @@ export const getAvailableSlots = (establishmentId, serviceId, date, staffId = nu
   );
 };
 
+/**
+ * Listado público (marketplace/directorio)
+ */
 export const getAllPublicEstablishments = () => {
   return apiClient('/public/establishments', 'GET');
 };
 
+/**
+ * Citas de un establecimiento (panel proveedor)
+ */
 export const getAppointmentsForEstablishment = (establishmentId, startDate, endDate) => {
   if (!establishmentId || !startDate || !endDate) {
     return Promise.reject(new Error('Faltan parámetros para obtener la agenda.'));


### PR DESCRIPTION
## Resumen
Este PR introduce:
- Siembra automática de festivos (Nager.Date) vía endpoint interno protegido.
- UI de configuración de festivos por establecimiento (country, region, types, years_ahead).
- Visualización de “blackouts” (días completos y parciales) sobre la Agenda del proveedor.
- Validaciones server-side para coherencia entre bloqueos completos y parciales.
- Bloqueo de creación/reprogramación de citas dentro de blackouts.

## Backend
- `app/routes/calendar.py`
  - `GET /api/calendar/blackouts`: listar bloqueos por establecimiento y rango.
  - `POST /api/calendar/blackouts`: crear bloqueos (día completo / parcial) con validaciones:
    - No permitir full-day si existen parciales ese día.
    - No permitir parcial si existe full-day ese día.
    - Evitar solapes entre parciales (hora_inicio < b.hora_fin && hora_fin > b.hora_inicio).
  - `DELETE /api/calendar/blackouts/:id`: eliminar bloqueo (autorización propietario).
  - `GET /api/calendar/holidays`: proxy Nager con filtros (country, region, types).
  - `POST /api/calendar/blackouts/seed-holidays`: siembra manual de festivos para un establecimiento.
  - `POST /api/internal/cron/seed-holidays` (con `X-CRON-SECRET`):
    - Recorre establecimientos con `holiday_auto_enabled=true`.
    - Siembra para [año actual .. año actual + holiday_years_ahead].
    - Actualiza `holiday_last_seed_year` y `holiday_last_sync_at`.

- `app/routes/appointment.py`
  - `create_appointment` y `reschedule_appointment` usan helper `_blackout_conflict` para bloquear horas no disponibles.

## Frontend
- Servicios:
  - `services/calendarService.js`: `getBlackouts`, `createBlackout`, `deleteBlackout`, `seedHolidays`.
  - `services/establishmentService.js`: soporta `params` en `apiClient`.
- Páginas:
  - `ProviderAppointments.jsx`:
    - Muestra blackouts como “background events” en FullCalendar.
    - Panel lateral para crear/eliminar bloqueos (día completo y parciales).
    - Validaciones cliente coherentes con el backend (full-day vs parciales, solapes).
- Ruta:
  - (Si aplica) `ProviderHolidaySettings.jsx` accesible desde `/dashboard/provider/holidays` y enlace desde Agenda.

## Config / Ops
- Se requiere `CRON_SECRET` en entorno o `Config`.
- Cron sugerido:
