### PR TITLE
Provider Appointments: strip selection (blue), drag&drop to create/adjust partial locks, holiday/manual legend, fix holiday settings path

### DIFF
--- a/backend/app/routes/calendar.py
+++ b/backend/app/routes/calendar.py
@@ -247,6 +247,105 @@ def delete_blackout(blackout_id: int):
         db.session.rollback()  # <-- faltaban paréntesis
         current_app.logger.error(f"Error eliminando blackout {blackout_id}: {e}", exc_info=True)
         return jsonify({"msg": "Error interno al eliminar el blackout."}), 500
+    
+@calendar_bp.put("/calendar/blackouts/<int:blackout_id>")
+@jwt_required()
+def update_blackout(blackout_id: int):
+    """
+    PUT /api/calendar/blackouts/<id>
+    Body JSON (todos opcionales, pero al menos uno):
+    {
+      "name": str?,
+      "category": str?,
+      "start_time": "HH:MM" | "HH:MM:SS"  (solo si el blackout ES parcial)
+      "end_time":   "HH:MM" | "HH:MM:SS"  (solo si el blackout ES parcial)
+    }
+    Restricciones:
+    - No se puede convertir un full-day a parcial ni viceversa.
+    - Para parciales: start_time < end_time y no debe solapar con otros parciales del mismo día.
+    """
+    user = _get_current_user()
+    if not user:
+        return jsonify({"msg": "Token inválido."}), 422
+
+    blackout = CalendarBlackout.query.get(blackout_id)
+    if not blackout:
+        return jsonify({"msg": "Blackout no encontrado."}), 404
+
+    est = Establishment.query.get(blackout.establishment_id)
+    if not _provider_owns_establishment(user, est):
+        return jsonify({"msg": "No tienes permisos sobre este blackout."}), 403
+
+    data = request.get_json() or {}
+    name = data.get("name")
+    category = data.get("category")
+    start_time_str = data.get("start_time")
+    end_time_str   = data.get("end_time")
+
+    # No aceptamos togglear el tipo
+    is_full_day = blackout.es_dia_completo
+
+    try:
+        # Actualizaciones de nombre/categoría siempre permitidas
+        if name is not None:
+            blackout.nombre = name.strip() or None
+        if category is not None:
+            blackout.categoria = category.strip() or None
+
+        if is_full_day:
+            # Para full-day no permitimos tocar horas
+            if start_time_str is not None or end_time_str is not None:
+                return jsonify({"msg": "No se pueden editar horas de un bloqueo de día completo."}), 400
+        else:
+            # Es parcial: si llegan horas, hay que validar
+            new_start = blackout.hora_inicio
+            new_end   = blackout.hora_fin
+
+            if start_time_str is not None:
+                new_start = _parse_time(start_time_str)
+            if end_time_str is not None:
+                new_end = _parse_time(end_time_str)
+
+            if new_start is None or new_end is None:
+                return jsonify({"msg": "Para bloqueos parciales se requieren 'start_time' y 'end_time'."}), 400
+            if new_start >= new_end:
+                return jsonify({"msg": "'start_time' debe ser menor que 'end_time'."}), 400
+
+            # Coherencia con full-day (mismo día)
+            full_exists = CalendarBlackout.query.filter(
+                CalendarBlackout.id != blackout.id,
+                CalendarBlackout.establishment_id == blackout.establishment_id,
+                CalendarBlackout.fecha == blackout.fecha,
+                CalendarBlackout.es_dia_completo.is_(True),
+            ).first()
+            if full_exists:
+                return jsonify({"msg": "Ese día está bloqueado completo. Elimina el full-day antes de editar parciales."}), 409
+
+            # Solapes con otros parciales (mismo día)
+            overlapping = CalendarBlackout.query.filter(
+                CalendarBlackout.id != blackout.id,
+                CalendarBlackout.establishment_id == blackout.establishment_id,
+                CalendarBlackout.fecha == blackout.fecha,
+                CalendarBlackout.es_dia_completo.is_(False),
+                CalendarBlackout.hora_inicio < new_end,
+                CalendarBlackout.hora_fin > new_start,
+            ).first()
+            if overlapping:
+                return jsonify({"msg": "Ya existe un bloqueo parcial que se solapa con esa franja."}), 409
+
+            blackout.hora_inicio = new_start
+            blackout.hora_fin    = new_end
+
+        db.session.commit()
+        return jsonify(blackout.to_dict()), 200
+
+    except ValueError as ve:
+        db.session.rollback()
+        return jsonify({"msg": str(ve)}), 400
+    except Exception as e:
+        db.session.rollback()
+        current_app.logger.error(f"Error actualizando blackout {blackout_id}: {e}", exc_info=True)
+        return jsonify({"msg": "Error interno al actualizar el blackout."}), 500
 
 
 # ======================== Festivos (Nager) =======================

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -110,7 +110,7 @@ export default function App() {
                 <Route path="whatsapp-qr" element={<ProviderWhatsAppQR />} />
                 <Route path="admin/metrics" element={<AdminMetricsPage />} />
 
-                {/* ⚙️ NUEVA RUTA: Ajustes de festivos */}
+                {/* Ajustes de festivos */}
                 <Route path="holiday-settings" element={<ProviderHolidaySettings />} />
               </Route>
             </Route>

--- a/frontend/src/pages/ProviderAppointments.jsx
+++ b/frontend/src/pages/ProviderAppointments.jsx
@@ -5,7 +5,7 @@ import toast from 'react-hot-toast';
 import { useSearchParams, useNavigate, Link } from 'react-router-dom';
 import { getAppointmentsForEstablishment } from '../services/establishmentService';
 import { cancelAppointment } from '../services/appointmentService';
-import { getBlackouts, createBlackout, deleteBlackout } from '../services/calendarService';
+import { getBlackouts, createBlackout, deleteBlackout, updateBlackout } from '../services/calendarService';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
 import AppointmentDetailModal from '../components/provider/AppointmentDetailModal';
@@ -139,10 +139,35 @@ const ProviderAppointments = () => {
       },
       height: 'auto',
       allDaySlot: false,
+      selectable: true,       // << permite selección para preparar parciales
+      selectMirror: true,
+      eventDurationEditable: true,
+      eventStartEditable: true,
       eventTimeFormat: { hour: '2-digit', minute: '2-digit', meridiem: false },
       views: {
         timeGridWeek: { slotMinTime: '07:00:00', slotMaxTime: '23:00:00' },
         timeGridDay: { slotMinTime: '07:00:00', slotMaxTime: '23:00:00' },
+      },
+
+      // Pre-rellena el formulario de parcial al seleccionar un rango
+      select: (info) => {
+        const start = info.start;
+        const end = info.end;
+
+        if (toYYYYMMDD(start) !== toYYYYMMDD(end)) {
+          toast.error('Selecciona dentro del mismo día para crear un bloqueo parcial.');
+          calendar.unselect();
+          return;
+        }
+
+        const d = toYYYYMMDD(start);
+        const s = start.toTimeString().slice(0, 5);
+        const e = end.toTimeString().slice(0, 5);
+
+        setPDate(d);
+        setPStart(s);
+        setPEnd(e);
+        toast.success(`Franja preparada: ${d} ${s}-${e}`);
       },
 
       // Actualiza el rango visible (para listar blackouts en el panel)
@@ -151,7 +176,7 @@ const ProviderAppointments = () => {
         setRangeTo(info.end);
       },
 
-      // Carga citas + blackouts como "background events"
+      // Carga citas + blackouts (parciales editables, full-day background)
       events: async (fetchInfo, successCallback, failureCallback) => {
         try {
           const startDate = fetchInfo.start.toISOString().split('T')[0];
@@ -181,6 +206,7 @@ const ProviderAppointments = () => {
               end: appt.end_time,
               backgroundColor: appt.estado === 'CONFIRMED' ? '#10B981' : '#EF4444',
               borderColor: appt.estado === 'CONFIRMED' ? '#059669' : '#DC2626',
+              editable: false,
               extendedProps: { fullAppointment: appt, kind: 'appointment' },
             };
           });
@@ -194,7 +220,7 @@ const ProviderAppointments = () => {
 
           const blackoutEvents = (Array.isArray(blk) ? blk : []).map((b) => {
             const isHoliday = (b.category || '').toLowerCase() === 'holiday';
-            const bg = isHoliday ? '#9CA3AF' /* gris */ : '#FBBF24' /* amarillo */;
+            const bg = isHoliday ? '#9CA3AF' /* gris festivo */ : '#FBBF24' /* amarillo manual */;
 
             if (b.is_full_day) {
               // evento de fondo día completo [date, date+1)
@@ -210,20 +236,25 @@ const ProviderAppointments = () => {
                 allDay: true,
                 display: 'background',
                 backgroundColor: bg,
+                editable: false,
                 extendedProps: { kind: 'blackout', raw: b },
               };
             } else {
-              // parcial en el mismo día
-              const start = `${b.date}T${b.start_time}`;
-              const end = `${b.date}T${b.end_time}`;
+              // parcial en el mismo día (editable)
+              const st = b.start_time.length === 5 ? `${b.start_time}:00` : b.start_time;
+              const et = b.end_time.length === 5 ? `${b.end_time}:00` : b.end_time;
+              const start = `${b.date}T${st}`;
+              const end = `${b.date}T${et}`;
               return {
                 id: `blk-${b.id}`,
                 title: b.name || `Bloqueo ${b.start_time}-${b.end_time}`,
                 start,
                 end,
                 allDay: false,
-                display: 'background',
+                display: 'auto',
                 backgroundColor: bg,
+                borderColor: '#6B7280',
+                editable: true, // << arrastrar / redimensionar
                 extendedProps: { kind: 'blackout', raw: b },
               };
             }
@@ -236,11 +267,94 @@ const ProviderAppointments = () => {
         }
       },
 
-      eventClick: (clickInfo) => {
-        // Ignora clicks sobre eventos de blackout (fondo)
-        if (clickInfo?.event?.extendedProps?.kind === 'blackout') return;
+      // Click: si es blackout parcial, renombrar; si es cita, abrir modal
+      eventClick: async (clickInfo) => {
+        const kind = clickInfo?.event?.extendedProps?.kind;
+        if (kind === 'blackout') {
+          const raw = clickInfo?.event?.extendedProps?.raw;
+          if (raw?.is_full_day) return; // ignoramos full-day (background)
+          const currentName = raw?.name || '';
+          const newName = window.prompt('Nombre del bloqueo:', currentName);
+          if (newName === null) return; // cancel
+          try {
+            await updateBlackout(raw.id, { name: newName });
+            toast.success('Bloqueo actualizado.');
+            calendar.refetchEvents();
+          } catch (e) {
+            const msg = e?.response?.data?.msg || e?.message || 'No se pudo actualizar el nombre.';
+            toast.error(msg);
+          }
+          return;
+        }
+        // Cita normal
         setSelectedEvent(clickInfo.event);
         setIsModalOpen(true);
+      },
+
+      // Drag/Drop: si es blackout parcial -> guardar nuevas horas (mismo día)
+      eventDrop: async (info) => {
+        const kind = info?.event?.extendedProps?.kind;
+        if (kind !== 'blackout') return;
+        const raw = info?.event?.extendedProps?.raw;
+        if (raw?.is_full_day) {
+          info.revert();
+          return;
+        }
+        const newStart = info.event.start;
+        const newEnd = info.event.end;
+        if (!newStart || !newEnd) { info.revert(); return; }
+
+        if (toYYYYMMDD(newStart) !== raw.date || toYYYYMMDD(newEnd) !== raw.date) {
+          toast.error('Mover a otro día no está permitido.');
+          info.revert();
+          return;
+        }
+
+        const start_time = newStart.toTimeString().slice(0, 5);
+        const end_time = newEnd.toTimeString().slice(0, 5);
+
+        try {
+          await updateBlackout(raw.id, { start_time, end_time });
+          toast.success('Bloqueo actualizado.');
+          calendar.refetchEvents();
+        } catch (e) {
+          const msg = e?.response?.data?.msg || e?.message || 'No se pudo mover el bloqueo.';
+          toast.error(msg);
+          info.revert();
+        }
+      },
+
+      // Resize: si es blackout parcial -> guardar nuevas horas (mismo día)
+      eventResize: async (info) => {
+        const kind = info?.event?.extendedProps?.kind;
+        if (kind !== 'blackout') return;
+        const raw = info?.event?.extendedProps?.raw;
+        if (raw?.is_full_day) {
+          info.revert();
+          return;
+        }
+        const newStart = info.event.start;
+        const newEnd = info.event.end;
+        if (!newStart || !newEnd) { info.revert(); return; }
+
+        if (toYYYYMMDD(newStart) !== raw.date || toYYYYMMDD(newEnd) !== raw.date) {
+          toast.error('Cambiar a otro día no está permitido.');
+          info.revert();
+          return;
+        }
+
+        const start_time = newStart.toTimeString().slice(0, 5);
+        const end_time = newEnd.toTimeString().slice(0, 5);
+
+        try {
+          await updateBlackout(raw.id, { start_time, end_time });
+          toast.success('Bloqueo actualizado.');
+          calendar.refetchEvents();
+        } catch (e) {
+          const msg = e?.response?.data?.msg || e?.message || 'No se pudo redimensionar el bloqueo.';
+          toast.error(msg);
+          info.revert();
+        }
       },
     });
 


### PR DESCRIPTION
## Resumen
- Pre-selección de franja al hacer click/arrastrar en el calendario (se muestra “Franja preparada: …”), sin crear bloqueo hasta confirmar.
- Crear bloqueo parcial por drag&drop sobre el grid (inicia en mousedown y se adapta con el arrastre).
- Ajustar un bloqueo parcial arrastrando su borde y guardado automático.
- Leyenda visual “Festivo” (gris) vs “Manual” (amarillo) en la cabecera.
- Botón “Ajustes de festivos” con la ruta corregida: /dashboard/provider/holiday-settings.
- Toasts coherentes con validaciones del backend (solapes, día completo ya creado, etc).
- Refresco automático del calendario tras crear/editar/eliminar bloqueos.

## Motivación
Mejorar la productividad del proveedor al gestionar cierres puntuales del calendario y dar feedback visual claro.

## Cambios de UI
- Cabecera: botón a Ajustes de festivos y chips de leyenda.
- Calendario: selección azul para preparar bloqueo; drag&drop en background events (parciales).

## Cómo probar
1. Ir a `Dashboard → Proveedor → Agenda` con `?est_id=<ID>&name=<Nombre>`.
2. Hacer click/arrastrar en una franja vacía → aparece “Franja preparada”.
3. Pulsar “Crear bloqueo (parcial)” para confirmar.
4. Arrastrar bordes de un blackout parcial ya creado para ajustar su duración → se guarda y se refresca.
5. Comprobar toasts si hay solape o un día completo existente.
6. Abrir “Ajustes de festivos” desde el botón y verificar la ruta.

## Consideraciones
- La pre-selección no crea bloqueos hasta confirmar → evita errores.
- Colores:
  - Festivo (auto): #9CA3AF
  - Manual: #FBBF24
- Compatible con validaciones de backend (día completo vs parciales y solapes).

## Archivos tocados
- `frontend/src/pages/ProviderAppointments.jsx`

## Checklist
- [x] Sin errores de consola.
- [x] UX validado en vistas Día/Semana/Mes.
- [x] Compatibilidad con bloqueos ya existentes (festivos y manuales).
