### PR TITLE
Feature/server staff filter

### DIFF
--- a/backend/app/routes/establishment.py
+++ b/backend/app/routes/establishment.py
@@ -456,3 +456,91 @@ def _is_public_holiday(establishment, day_local):
     region  = getattr(establishment, "region_code", None)  # ej. 'VC'
     hcal = pyholidays.country_holidays(country, subdiv=region, years=[day_local.year])
     return day_local in hcal
+
+# PATCH: actualizar campos simples de una cita (ej. staff_id)
+@establishment_bp.route('/appointments/<int:appointment_id>', methods=['PATCH'])
+@jwt_required()
+def patch_appointment(appointment_id):
+    """
+    PATCH /api/appointments/<appointment_id>
+    Body JSON (cualquiera de estos campos, todos opcionales):
+      - staff_id: int | null   -> reasigna el empleado (o lo limpia con null)
+      - estado: str            -> (opcional) actualizar estado si lo necesitas
+
+    Requisitos:
+      - El provider autenticado debe ser propietario del establecimiento de la cita.
+      - Si se asigna staff_id, el Staff debe pertenecer al mismo establecimiento y estar activo.
+      - (Opcional) Si el servicio de la cita limita staff, validamos que el staff pueda realizarlo.
+    """
+    provider_id = get_provider_id_from_jwt()
+    if not provider_id:
+        return jsonify({"msg": "Token inválido"}), 422
+
+    appt = Appointment.query.get(appointment_id)
+    if not appt:
+        return jsonify({"msg": "Cita no encontrada"}), 404
+
+    service = Service.query.get(appt.service_id)
+    if not service:
+        return jsonify({"msg": "Servicio asociado no encontrado"}), 404
+
+    establishment = Establishment.query.get(service.establishment_id)
+    if not establishment or establishment.provider_id != provider_id:
+        return jsonify({"msg": "Acceso denegado"}), 403
+
+    data = request.get_json(silent=True) or {}
+    updated = False
+
+    # ---- Reasignar / limpiar staff_id ----
+    if "staff_id" in data:
+        new_staff_id = data.get("staff_id", None)
+
+        if new_staff_id is None:
+            # Limpiar asignación
+            appt.staff_id = None
+            updated = True
+        else:
+            try:
+                new_staff_id = int(new_staff_id)
+            except (TypeError, ValueError):
+                return jsonify({"msg": "staff_id debe ser entero o null"}), 400
+
+            staff = Staff.query.get(new_staff_id)
+            if not staff:
+                return jsonify({"msg": "Staff no encontrado"}), 404
+            if staff.establishment_id != establishment.id:
+                return jsonify({"msg": "Ese staff no pertenece a este establecimiento"}), 400
+            if staff.activo is False:
+                return jsonify({"msg": "Ese staff está inactivo"}), 400
+
+            # (Opcional) Validar que el staff presta este servicio
+            try:
+                # Si tu modelo de Service expone lista de staff_ids
+                allowed_staff_ids = set(service.staff_ids or [])
+            except Exception:
+                allowed_staff_ids = set()
+
+            if allowed_staff_ids and new_staff_id not in allowed_staff_ids:
+                return jsonify({"msg": "Ese staff no está habilitado para este servicio"}), 400
+
+            appt.staff_id = new_staff_id
+            updated = True
+
+    # ---- (Opcional) actualizar estado ----
+    if "estado" in data:
+        # Valida según tus estados permitidos si quieres
+        appt.estado = data["estado"]
+        updated = True
+
+    if not updated:
+        return jsonify({"msg": "Nada que actualizar"}), 400
+
+    try:
+        db.session.commit()
+        # Si tu Appointment.to_dict() ya incluye staff_member expandido, genial;
+        # si no, devuelve al menos el staff_id actualizado.
+        return jsonify(appt.to_dict()), 200
+    except Exception as e:
+        db.session.rollback()
+        current_app.logger.error(f"Error en PATCH cita {appointment_id}: {e}", exc_info=True)
+        return jsonify({"msg": "Error interno al actualizar la cita"}), 500

--- a/backend/app/routes/establishment.py
+++ b/backend/app/routes/establishment.py
@@ -143,7 +143,7 @@ def get_available_slots(establishment_id):
                 working_intervals.append({
                     "staff_id": member.id,
                     "start": datetime.combine(start_of_day_local.date(), rule.hora_inicio, tzinfo=provider_tz),
-                    "end": datetime.combine(start_of_day_local.date(), rule.hora_fin, tzinfo=provider_tz)
+                    "end": datetime.combine(start_of_day_local.date(), rule.hora_fin,   tzinfo=provider_tz)
                 })
     else:
         rules = AvailabilityRule.query.filter_by(
@@ -157,7 +157,7 @@ def get_available_slots(establishment_id):
         working_intervals = [{
             "staff_id": None,
             "start": datetime.combine(start_of_day_local.date(), rule.hora_inicio, tzinfo=provider_tz),
-            "end": datetime.combine(start_of_day_local.date(), rule.hora_fin, tzinfo=provider_tz)
+            "end": datetime.combine(start_of_day_local.date(), rule.hora_fin,   tzinfo=provider_tz)
         } for rule in rules]
 
     # --- 4. Generación de huecos ---
@@ -346,7 +346,13 @@ def get_establishment_appointments(establishment_id):
     GET /api/establishments/<id>/appointments
     -----------------------------------------
     Obtiene las citas de un establecimiento para un rango de fechas.
-    Acepta parámetros 'start' y 'end' (YYYY-MM-DD).
+    Acepta parámetros:
+      - 'start' y 'end' (YYYY-MM-DD)  ✅
+      - o 'start_date' y 'end_date' (YYYY-MM-DD) ✅ (compatibilidad)
+    Opcionales:
+      - 'staff_id' para filtrar por empleado
+      - 'status' (p.ej. CONFIRMED, PENDING_PROVIDER, CANCELLED). Si viene con
+        varios separados por coma, se aplicará un IN.
     """
     provider_id = get_provider_id_from_jwt()
     if not provider_id:
@@ -359,23 +365,43 @@ def get_establishment_appointments(establishment_id):
     if establishment.provider_id != provider_id:
         return jsonify({"msg": "No tienes permiso para ver las citas de este establecimiento."}), 403
 
-    start_str = request.args.get('start')
-    end_str = request.args.get('end')
+    # Soporta 'start/end' y 'start_date/end_date'
+    start_str = request.args.get('start') or request.args.get('start_date')
+    end_str   = request.args.get('end')   or request.args.get('end_date')
 
     if not start_str or not end_str:
-        return jsonify({"msg": "Los parámetros 'start' y 'end' son requeridos."}), 400
+        return jsonify({"msg": "Los parámetros 'start' y 'end' (o 'start_date' y 'end_date') son requeridos."}), 400
 
     try:
         start_date = datetime.strptime(start_str, '%Y-%m-%d').date()
-        end_date = datetime.strptime(end_str, '%Y-%m-%d').date()
+        end_date   = datetime.strptime(end_str,   '%Y-%m-%d').date()
     except ValueError:
         return jsonify({"msg": "Formato de fecha inválido. Usa YYYY-MM-DD."}), 400
 
+    # Normalizamos a datetimes UTC (inicio del día y del día siguiente)
+    # end_date se toma como EXCLUSIVO (estilo FullCalendar)
+    start_dt_utc = datetime.combine(start_date, time.min, tzinfo=timezone.utc)
+    end_dt_utc   = datetime.combine(end_date,   time.min, tzinfo=timezone.utc)
+
+    # Filtros opcionales
+    staff_id = request.args.get('staff_id', type=int)
+    status_param = request.args.get('status')  # Puede ser simple o lista separada por comas
+
     query = Appointment.query.join(Service).filter(
         Service.establishment_id == establishment_id,
-        Appointment.start_time >= start_date,
-        Appointment.start_time < end_date
+        Appointment.start_time >= start_dt_utc,
+        Appointment.start_time < end_dt_utc
     )
+
+    if staff_id is not None:
+        query = query.filter(Appointment.staff_id == staff_id)
+
+    if status_param:
+        statuses = [s.strip() for s in status_param.split(',') if s.strip()]
+        if len(statuses) == 1:
+            query = query.filter(Appointment.estado == statuses[0])
+        elif len(statuses) > 1:
+            query = query.filter(Appointment.estado.in_(statuses))
 
     appointments = query.order_by(Appointment.start_time.asc()).all()
     return jsonify([appt.to_dict() for appt in appointments]), 200


### PR DESCRIPTION
¿Qué incluye?

GET /api/establishments/<id>/available-slots

Nuevo parámetro opcional staff_id para filtrar huecos por empleado concreto.

Respeta:

Modo multi-staff (has_multiple_staff) y reglas de disponibilidad por empleado.

Festivos/bloqueos (full day y parciales).

Citas confirmadas o pendientes del proveedor (evita solapes).

Timezone-aware usando la zona horaria del proveedor.

GET /api/establishments/<id>/staff (privado)

Listado del personal activo del establecimiento (id, nombre, email, servicios, etc.).

Útil para poblar filtros en panel interno.

PATCH /api/appointments/<id>

Acepta staff_id (numérico) o null para asignar/desasignar empleado.

Validaciones:

El staff_id pertenece al establecimiento de la cita.

Si el servicio limita empleados (service.staff_ids), debe estar permitido.

Mantiene compatibilidad: si no se envía staff_id, no cambia.

Helpers

Cálculo de solapes, manejo de blackouts/festivos por día.

Normalización de comparaciones con TZ (UTC/local).

Motivación

Permitir:

Filtrar visibilidad de huecos y agendas por empleado.

Asignar o cambiar el empleado responsable de una cita ya creada.

Esto cierra la integración backend necesaria para el filtro de staff en el panel y prepara el terreno para selección de empleado en la reserva pública.

Testing manual (cURL simple)

Ajusta variables de entorno según tu entorno:
BASE="http://localhost:5000/api", TOKEN="...", EST_ID=1, APPT_ID=14, START=2025-09-15, END=2025-09-25.

1) Listar staff del establecimiento (privado)
curl -sS -H "Authorization: Bearer $TOKEN" \
  "$BASE/establishments/$EST_ID/staff"

2) Huecos disponibles por servicio y fecha (sin y con staff_id)
# Sin staff (cualquiera)
curl -sS "$BASE/establishments/$EST_ID/available-slots?service_id=1&date=2025-09-18"

# Filtrado por staff_id
curl -sS "$BASE/establishments/$EST_ID/available-slots?service_id=1&date=2025-09-18&staff_id=2"

3) Asignar / desasignar empleado a una cita (PATCH)
# Asignar
curl -sS -X PATCH "$BASE/appointments/$APPT_ID" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"staff_id": 2}'

# Desasignar
curl -sS -X PATCH "$BASE/appointments/$APPT_ID" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"staff_id": null}'

Compatibilidad / riesgos

BC: No rompe clientes actuales; staff_id es opcional.

Seguridad: Rutas privadas verifican JWT y pertenencia del provider/establishment.

Migraciones: No requiere cambios de esquema (usa campos existentes).

Riesgos: Validar correctamente timezones y solapes; cubierto en helpers.

Checklist

 available-slots acepta staff_id y filtra correctamente.

 Listado de staff privado operativo.

 PATCH /appointments/:id permite set/unset staff_id con validación.

 Logs de error y respuestas claras (400/403/404/409/500).

 Probado con cURL.