### PR TITLE
feat(establishments): toggle 'has_multiple_staff' en UI y backend PUT

### DIFF
--- a/backend/app/routes/establishment.py
+++ b/backend/app/routes/establishment.py
@@ -295,12 +295,23 @@ def update_establishment(establishment_id):
     editable_fields = [
         'nombre', 'direccion_completa', 'provincia', 'localidad',
         'codigo_postal', 'telefono', 'email', 'web', 'descripcion_publica', 'activo',
+        'has_multiple_staff',
         'holiday_auto_enabled', 'holiday_country_code', 'holiday_region_code',
         'holiday_types', 'holiday_years_ahead'
     ]
     for field in editable_fields:
         if field in data:
             setattr(establishment, field, data[field])
+    for field in editable_fields:
+        if field in data:
+            # Coerciones suaves para booleanos que podrían venir como string
+            if field in ('has_multiple_staff', 'holiday_auto_enabled', 'activo'):
+                val = data[field]
+                if isinstance(val, str):
+                    val = val.strip().lower() in ('1', 'true', 't', 'yes', 'y')
+                setattr(establishment, field, bool(val))
+            else:
+                setattr(establishment, field, data[field])
 
     # Normaliza region si viene vacía
     if 'holiday_region_code' in data and not data['holiday_region_code']:

--- a/frontend/src/pages/EditEstablishment.jsx
+++ b/frontend/src/pages/EditEstablishment.jsx
@@ -22,6 +22,7 @@ const EditEstablishment = () => {
     telefono: '',
     email: '',
     activo: true,
+    has_multiple_staff: false,
   });
 
   const [loading, setLoading] = useState(true);
@@ -43,6 +44,8 @@ const EditEstablishment = () => {
           telefono: data?.telefono != null ? String(data.telefono) : '',
           email: data?.email ?? '',
           activo: data?.activo !== undefined ? !!data.activo : true,
+          has_multiple_staff:
+            data?.has_multiple_staff !== undefined ? !!data.has_multiple_staff : false,
         });
       } catch (err) {
         toast.error(err.message || 'No se pudieron cargar los datos del establecimiento.');
@@ -93,6 +96,7 @@ const EditEstablishment = () => {
       telefono: formData.telefono ? String(formData.telefono).trim() : '',
       email: formData.email.trim(),
       activo: !!formData.activo,
+      has_multiple_staff: !!formData.has_multiple_staff,
     };
 
     // Validaciones rápidas
@@ -257,6 +261,35 @@ const EditEstablishment = () => {
                 Establecimiento activo (visible para clientes)
               </span>
             </label>
+          </div>
+
+          <div className="pt-2">
+            <label className="flex items-start gap-3">
+              <input
+                type="checkbox"
+                name="has_multiple_staff"
+                checked={formData.has_multiple_staff}
+                onChange={handleChange}
+                className="mt-1 h-4 w-4 rounded border-gray-300 text-brand-600 focus:ring-brand-500"
+              />
+              <span className="text-sm text-gray-900">
+                <span className="font-medium">Varios empleados (modo staff)</span>
+                <span className="block text-gray-600">
+                  Actívalo si ofreces citas con diferentes empleados. Podrás asignar citas a un empleado
+                  concreto, filtrar la agenda por empleado y permitir que el cliente elija empleado al
+                  reservar.
+                </span>
+              </span>
+            </label>
+            <div className="mt-2 text-xs text-gray-600">
+              Gestiona tu equipo en{' '}
+              <a
+                href={`/dashboard/provider/staff?est_id=${encodeURIComponent(establishmentId || '')}`}
+                className="underline hover:no-underline"
+              >
+                Empleados
+              </a>.
+            </div>
           </div>
 
           <div className="flex justify-end pt-4 gap-3">


### PR DESCRIPTION
Resumen

Este PR habilita el modo de varios empleados para los establecimientos:

Backend

PUT /establishments/:id ahora acepta y persiste has_multiple_staff (boolean).

Sin cambios de esquema (no requiere migraciones).

Frontend (Panel proveedor)

En Editar Establecimiento se añade el checkbox “Varios empleados (modo staff)” con descripción de ayuda.

El valor se carga desde el backend y se guarda con el resto del formulario.

Comportamiento de agenda y slots

Si has_multiple_staff = true: la disponibilidad/huecos se calculan a partir de las reglas de disponibilidad por empleado.

Si has_multiple_staff = false: la disponibilidad/huecos se calculan con las reglas del establecimiento (modo “un solo proveedor”).

Nota: Esto alinea la UX con el flujo real del negocio: comercios con 1 persona vs. comercios con varios empleados asignables.

Archivos destacados

Backend: backend/app/routes/establishment.py

Soporte de has_multiple_staff en la lista de campos editables del endpoint PUT.

Frontend: frontend/src/pages/EditEstablishment.jsx

UI del toggle y wiring con getEstablishmentById / updateEstablishment.

Cómo probar

Activar modo staff

# Activar
curl -sS -X PUT "$BASE/establishments/$EST_ID" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"has_multiple_staff": true}'
# Verificar
curl -sS -X GET "$BASE/establishments/$EST_ID" -H "Authorization: Bearer $TOKEN"


Desactivar modo staff

curl -sS -X PUT "$BASE/establishments/$EST_ID" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"has_multiple_staff": false}'


UI: En Dashboard → Establecimientos → Editar, marcar/desmarcar “Varios empleados (modo staff)” y guardar. Confirmar que:

El valor persiste (se recarga correctamente).

La obtención de huecos se corresponde con el modo elegido.

Impacto / Compatibilidad

Backward compatible: si no se toca el toggle, el comportamiento por defecto se mantiene.

No hay migraciones de base de datos.

No afecta a endpoints públicos de establecimentos.

Checklist

 Compila el frontend sin errores.

 PUT/GET de establecimiento probados con curl.

 Toggle visible y persistente en la UI.

 Comportamiento de slots alineado con el flag.