### PR TITLE
Server: filter by staff in agenda + anti-overlap validations/blackouts

### DIFF
--- a/backend/app/routes/establishment.py
+++ b/backend/app/routes/establishment.py
@@ -357,13 +357,10 @@ def get_establishment_appointments(establishment_id):
     GET /api/establishments/<id>/appointments
     -----------------------------------------
     Obtiene las citas de un establecimiento para un rango de fechas.
-    Acepta parámetros:
-      - 'start' y 'end' (YYYY-MM-DD)  ✅
-      - o 'start_date' y 'end_date' (YYYY-MM-DD) ✅ (compatibilidad)
-    Opcionales:
-      - 'staff_id' para filtrar por empleado
-      - 'status' (p.ej. CONFIRMED, PENDING_PROVIDER, CANCELLED). Si viene con
-        varios separados por coma, se aplicará un IN.
+    Parámetros:
+      - start (YYYY-MM-DD) (requerido)
+      - end   (YYYY-MM-DD) (requerido)  -> exclusivo
+      - staff_id (opcional)             -> filtra por empleado
     """
     provider_id = get_provider_id_from_jwt()
     if not provider_id:
@@ -376,27 +373,21 @@ def get_establishment_appointments(establishment_id):
     if establishment.provider_id != provider_id:
         return jsonify({"msg": "No tienes permiso para ver las citas de este establecimiento."}), 403
 
-    # Soporta 'start/end' y 'start_date/end_date'
-    start_str = request.args.get('start') or request.args.get('start_date')
-    end_str   = request.args.get('end')   or request.args.get('end_date')
+    start_str = request.args.get('start')
+    end_str = request.args.get('end')
+    staff_id_str = request.args.get('staff_id')
 
     if not start_str or not end_str:
-        return jsonify({"msg": "Los parámetros 'start' y 'end' (o 'start_date' y 'end_date') son requeridos."}), 400
+        return jsonify({"msg": "Los parámetros 'start' y 'end' son requeridos."}), 400
 
     try:
+        # rango diario en UTC (00:00 -> 00:00 del día siguiente)
         start_date = datetime.strptime(start_str, '%Y-%m-%d').date()
-        end_date   = datetime.strptime(end_str,   '%Y-%m-%d').date()
+        end_date = datetime.strptime(end_str, '%Y-%m-%d').date()
+        start_dt_utc = datetime.combine(start_date, time.min, tzinfo=timezone.utc)
+        end_dt_utc = datetime.combine(end_date, time.min, tzinfo=timezone.utc)
     except ValueError:
         return jsonify({"msg": "Formato de fecha inválido. Usa YYYY-MM-DD."}), 400
-
-    # Normalizamos a datetimes UTC (inicio del día y del día siguiente)
-    # end_date se toma como EXCLUSIVO (estilo FullCalendar)
-    start_dt_utc = datetime.combine(start_date, time.min, tzinfo=timezone.utc)
-    end_dt_utc   = datetime.combine(end_date,   time.min, tzinfo=timezone.utc)
-
-    # Filtros opcionales
-    staff_id = request.args.get('staff_id', type=int)
-    status_param = request.args.get('status')  # Puede ser simple o lista separada por comas
 
     query = Appointment.query.join(Service).filter(
         Service.establishment_id == establishment_id,
@@ -404,19 +395,16 @@ def get_establishment_appointments(establishment_id):
         Appointment.start_time < end_dt_utc
     )
 
-    if staff_id is not None:
+    # Filtro opcional por empleado
+    if staff_id_str:
+        try:
+            staff_id = int(staff_id_str)
+        except (TypeError, ValueError):
+            return jsonify({"msg": "staff_id debe ser entero."}), 400
         query = query.filter(Appointment.staff_id == staff_id)
-
-    if status_param:
-        statuses = [s.strip() for s in status_param.split(',') if s.strip()]
-        if len(statuses) == 1:
-            query = query.filter(Appointment.estado == statuses[0])
-        elif len(statuses) > 1:
-            query = query.filter(Appointment.estado.in_(statuses))
 
     appointments = query.order_by(Appointment.start_time.asc()).all()
     return jsonify([appt.to_dict() for appt in appointments]), 200
-
 
 # ----- Helpers para festivos / blackouts -----
 

--- a/frontend/src/pages/ProviderAppointments.jsx
+++ b/frontend/src/pages/ProviderAppointments.jsx
@@ -435,8 +435,11 @@ const ProviderAppointments = () => {
             staffFilter && staffFilter !== 'all' ? staffFilter : null
           );
 
-          // (Por compatibilidad) Si el backend aún no filtra por staffId, filtramos en cliente:
-          if (staffFilter !== 'all') {
+          // Solo filtra en cliente si NO has enviado staff_id al servidor
+          if (!staffFilter || staffFilter === 'all') {
+            // no filtramos
+          } else if (!Array.isArray(appointments) || appointments.some(a => a.staff_member === undefined)) {
+            // fallback: backend no devolvió staff_member claro -> filtramos en cliente
             const filterId = String(staffFilter);
             appointments = appointments.filter(a => String(a?.staff_member?.id || '') === filterId);
           }

--- a/frontend/src/services/establishmentService.js
+++ b/frontend/src/services/establishmentService.js
@@ -96,15 +96,22 @@ export const getAllPublicEstablishments = () => {
 
 /**
  * Citas de un establecimiento (panel proveedor)
+ * Ahora acepta staffId opcional para filtrar en servidor.
  */
-export const getAppointmentsForEstablishment = (establishmentId, startDate, endDate) => {
+export const getAppointmentsForEstablishment = (establishmentId, startDate, endDate, staffId) => {
   if (!establishmentId || !startDate || !endDate) {
     return Promise.reject(new Error('Faltan parámetros para obtener la agenda.'));
   }
+
+  const params = { start: startDate, end: endDate };
+  if (staffId && staffId !== 'all') {
+    params.staff_id = staffId;
+  }
+
   return apiClient(
     `/establishments/${establishmentId}/appointments`,
     'GET',
     null,
-    { params: { start: startDate, end: endDate } }
+    { params }
   );
 };


### PR DESCRIPTION
Resumen

Backend

GET /api/establishments/:id/appointments?start=YYYY-MM-DD&end=YYYY-MM-DD&staff_id=OPCIONAL

Nuevo filtro opcional staff_id (cuando has_multiple_staff = true).

Respeta estados CONFIRMED y PENDING_PROVIDER.

Validaciones anti-solape por empleado al crear y actualizar citas:

Si viene staff_id, valida:

El staff pertenece al establecimiento y está activo.

(Si aplica) El staff presta el servicio de la cita.

No existe otra cita solapada (mismo staff_id).

Respeta blackouts (día completo y parciales) del establecimiento.

PATCH /api/appointments/:id:

Permite reasignar staff_id (incluye validaciones anteriores).

Permite actualizar estado (con las restricciones actuales).

Mensajería de errores clara con 400/403/404/409.

Frontend

getAppointmentsForEstablishment(establishmentId, start, end, staffId?) admite staffId opcional.

Calendario del panel proveedor:

Llama al endpoint con staffFilter cuando es distinto de all.

Mantiene compatibilidad retro (filtrado en cliente si el backend no filtrase).

Motivación

Permitir a negocios con varios empleados gestionar su agenda por profesional, evitando overbookings y respetando los bloqueos de calendario.

Notas de implementación

El cálculo de available-slots ya considera staff_id, solapes, festivos/blackouts y TZ del proveedor.

Si has_multiple_staff está activo y no se envía staff_id en POST /appointments, se intenta asignación automática a un staff disponible que presta el servicio.

Cómo probar (resumen)

Huecos por staff

GET /api/establishments/:id/available-slots?service_id=:sid&date=YYYY-MM-DD&staff_id=:st


Crear cita (cliente)

POST /api/appointments
{ "service_id": 2, "start_time": "2025-10-20T09:00:00Z", "staff_id": 1 }


Listar agenda con filtro

GET /api/establishments/:id/appointments?start=2025-10-01&end=2025-11-01&staff_id=1


Reasignar staff (proveedor)

PATCH /api/appointments/:id
{ "staff_id": 2 }


Blackouts

Cualquier intento en día completo o franja parcial devuelve 409 con mensaje claro.

Resultados de pruebas locales

Creación de cita con staff_id ✅

Filtro staff_id en agenda ✅

Reasignación staff_id por proveedor ✅

Rechazo por blackout (día completo) con 409 ✅

Sin solapes por empleado ✅

Checklist

 Endpoint agenda con filtro por staff_id.

 Validaciones servidor (pertenencia, servicio, solapes, blackouts).

 Front actualizado para pasar staffFilter.

 Mensajería de error clara (400/403/404/409).

 Tests manuales con curl (adjuntos arriba).